### PR TITLE
Mention max limit when listing routes

### DIFF
--- a/source/api-routes.rst
+++ b/source/api-routes.rst
@@ -78,7 +78,7 @@ account, not per domain as most of other API calls.
  ================= ==========================================================
  Parameter         Description
  ================= ==========================================================
- limit             Maximum number of records to return. (100 by default)
+ limit             Maximum number of records to return. (100 by default, 1000 max)
  skip              Number of records to skip. (0 by default)
  ================= ==========================================================
 


### PR DESCRIPTION
Found out through experimentation that the max limit is 1000 records. Any higher than that results in a 400 Bad Request.

Note that the max limit for routes is 5000, so currently you're unable to get all your routes this way if they exceed 1000. I'll contact Mailgun Support about this.