### PR TITLE
Switch sample accounts to placeholders

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -215,6 +215,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       {%- if customsidebar %}
       {% include customsidebar %}
       {%- endif %}
+      <div class="admonition info">You can find your API Key in your <a href="https://mailgun.com/cp">Control Panel</a></div>
     </div>
   </aside>
   {%- endif %}{% endif %}

--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -215,7 +215,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       {%- if customsidebar %}
       {% include customsidebar %}
       {%- endif %}
-      <div class="admonition info">You can find your API Key in your <a href="https://mailgun.com/cp">Control Panel</a></div>
+      <div class="admonition note">You can find your API Key in your <a href="https://mailgun.com/cp" target="_blank">Control Panel</a></div>
     </div>
   </aside>
   {%- endif %}{% endif %}

--- a/source/samples/add-bounce.rst
+++ b/source/samples/add-bounce.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/bounces \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/bounces \
 	-F address='bob@example.com'
 
 .. code-block:: java
@@ -10,9 +10,9 @@
  public static ClientResponse AddBounce() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/" +
  				"bounces");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("address", "bob@example.com");
@@ -26,8 +26,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->post("$domain/bounces", array('address' => 'bob@example.com'));
@@ -36,15 +36,15 @@
 
  def add_bounce():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/bounces",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/bounces",
+         auth=("api", "YOUR_API_KEY"),
          data={'address':'bob@example.com'})
 
 .. code-block:: rb
 
  def add_bounce
-   RestClient.post("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-                   "@api.mailgun.net/v2/samples.mailgun.org/bounces",
+   RestClient.post("https://api:YOUR_API_KEY"\
+                   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/bounces",
                    :address => 'bob@example.com')
  end
 
@@ -55,11 +55,11 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "{domain}/bounces";
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("address", "bob@example.com");
  	request.Method = Method.POST;
  	return client.Execute(request);

--- a/source/samples/add-complaint.rst
+++ b/source/samples/add-complaint.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/complaints \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/complaints \
 	-F address='bob@example.com'
 
 .. code-block:: java
@@ -10,9 +10,9 @@
  public static ClientResponse AddComplaint() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/" +
  				"complaints");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("address", "bob@example.com");
@@ -27,8 +27,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   
   # Issue the call to the client.
   $result = $mgClient->post("$domain/complaints", array('address' => 'bob@example.com'));
@@ -37,15 +37,15 @@
 
  def add_complaint():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/complaints",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/complaints",
+         auth=("api", "YOUR_API_KEY"),
          data={'address': 'bob@example.com'})
 
 .. code-block:: rb
 
  def add_complaint
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/complaints",
+   RestClient.post "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/complaints",
    :address => 'bob@example.com'
  end
 
@@ -56,11 +56,11 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "{domain}/complaints";
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("address", "bob@example.com");
  	request.Method = Method.POST;
  	return client.Execute(request);

--- a/source/samples/add-domain.rst
+++ b/source/samples/add-domain.rst
@@ -1,9 +1,9 @@
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
+    curl -s --user 'api:YOUR_API_KEY' \
 	-X POST \
 	https://api.mailgun.net/v2/domains \
-	-F name='samples.mailgun.org' \
+	-F name='YOUR_DOMAIN_NAME' \
 	-F smtp_password='supersecretpassword'
 
 .. code-block:: java
@@ -11,11 +11,11 @@
  public static ClientResponse AddDomain() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/domains");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
- 	formData.add("name", "samples.mailgun.org");
+ 	formData.add("name", "YOUR_DOMAIN_NAME");
  	formData.add("smtp_password", "supersecretpassword");
  	return webResource.type(MediaType.APPLICATION_FORM_URLENCODED).
  		post(ClientResponse.class, formData);
@@ -28,8 +28,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->post("domains", array(
@@ -42,15 +42,15 @@
  def add_domain():
      return requests.post(
          "https://api.mailgun.net/v2/domains",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
-         data={'name':'samples.mailgun.org', 'smtp_password':'supersecretpassword'})
+         auth=("api", "YOUR_API_KEY"),
+         data={'name':'YOUR_DOMAIN_NAME', 'smtp_password':'supersecretpassword'})
 
 .. code-block:: rb
 
  def add_domain
-   RestClient.post("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
+   RestClient.post("https://api:YOUR_API_KEY"\
                    "@api.mailgun.net/v2/domains",
-                   :name => 'samples.mailgun.org',
+                   :name => 'YOUR_DOMAIN_NAME',
                    :smtp_password => 'supersecretpassword')
  end
 
@@ -61,10 +61,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2/";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "domains";
- 	request.AddParameter("name", "samples.mailgun.org");
+ 	request.AddParameter("name", "YOUR_DOMAIN_NAME");
  	request.AddParameter("smtp_password", "supersecretpassword");
  	request.Method = Method.POST;
  	return client.Execute(request);
@@ -74,5 +74,5 @@
 
 func AddDomain(domain, apiKey string) error {
   mg := mailgun.NewMailgun(domain, apiKey, "")
-  return mg.CreateDomain("samples.mailgun.org", "supersecretpassword", mailgun.Tag, false)
+  return mg.CreateDomain("YOUR_DOMAIN_NAME", "supersecretpassword", mailgun.Tag, false)
 }

--- a/source/samples/add-list-member.rst
+++ b/source/samples/add-list-member.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/lists/dev@samples.mailgun.org/members \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members \
 	-F subscribed=True \
 	-F address='bar@example.com' \
 	-F name='Bob Bar' \
@@ -14,10 +14,10 @@
  public static ClientResponse AddListMember() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@samples.mailgun.org/members");
+ 				"dev@YOUR_DOMAIN_NAME/members");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("address", "bar@example.com");
  	formData.add("subscribed", true);
@@ -35,8 +35,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $listAddress = 'dev@samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $listAddress = 'dev@YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->post("lists/$listAddress/members", array(
@@ -51,8 +51,8 @@
 
  def add_list_member():
      return requests.post(
-         "https://api.mailgun.net/v2/lists/dev@samples.mailgun.org/members",
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'),
+         "https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members",
+         auth=('api', 'YOUR_API_KEY'),
          data={'subscribed': True,
                'address': 'bar@example.com',
                'name': 'Bob Bar',
@@ -62,8 +62,8 @@
 .. code-block:: rb
 
  def add_list_member
-   RestClient.post("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0" \
-                   "@api.mailgun.net/v2/lists/dev@samples.mailgun.org/members",
+   RestClient.post("https://api:YOUR_API_KEY" \
+                   "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members",
                    :subscribed => true,
                    :address => 'bar@example.com',
                    :name => 'Bob Bar',
@@ -78,10 +78,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}/members";
- 	request.AddParameter("list", "dev@samples.mailgun.org", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("address", "bar@example.com");
  	request.AddParameter("subscribed", true);
  	request.AddParameter("name", "Bob Bar");

--- a/source/samples/add-list-member.rst
+++ b/source/samples/add-list-member.rst
@@ -2,7 +2,7 @@
 .. code-block:: bash
 
     curl -s --user 'api:YOUR_API_KEY' \
-	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members \
+	https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members \
 	-F subscribed=True \
 	-F address='bar@example.com' \
 	-F name='Bob Bar' \
@@ -17,7 +17,7 @@
  			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@YOUR_DOMAIN_NAME/members");
+ 				"LIST@YOUR_DOMAIN_NAME/members");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("address", "bar@example.com");
  	formData.add("subscribed", true);
@@ -36,7 +36,7 @@
 
   # Instantiate the client.
   $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'dev@YOUR_DOMAIN_NAME';
+  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->post("lists/$listAddress/members", array(
@@ -51,7 +51,7 @@
 
  def add_list_member():
      return requests.post(
-         "https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members",
+         "https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members",
          auth=('api', 'YOUR_API_KEY'),
          data={'subscribed': True,
                'address': 'bar@example.com',
@@ -63,7 +63,7 @@
 
  def add_list_member
    RestClient.post("https://api:YOUR_API_KEY" \
-                   "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members",
+                   "@api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members",
                    :subscribed => true,
                    :address => 'bar@example.com',
                    :name => 'Bob Bar',
@@ -81,7 +81,7 @@
  		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}/members";
- 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "LIST@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("address", "bar@example.com");
  	request.AddParameter("subscribed", true);
  	request.AddParameter("name", "Bob Bar");

--- a/source/samples/add-list-members.rst
+++ b/source/samples/add-list-members.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/lists/dev@samples.mailgun.org/members.json \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members.json \
 	-F upsert=true \
 	-F members='[{"address": "Alice <alice@example.com>", "vars": {"age": 26}},{"name": "Bob", "address": "bob@example.com", "vars": {"age": 34}}]'
 
@@ -11,10 +11,10 @@
  public static ClientResponse AddListMember() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@samples.mailgun.org/members.json");
+ 				"dev@YOUR_DOMAIN_NAME/members.json");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("members", "[{"address": "Alice <alice@example.com>", "vars": {"age": 26}},{"name": "Bob", "address": "bob@example.com", "vars": {"age": 34}}]");
  	formData.add("upsert", true);
@@ -29,8 +29,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $listAddress = 'dev@samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $listAddress = 'dev@YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->post("lists/$listAddress/members.json", array(
@@ -42,16 +42,16 @@
 
  def add_list_member():
      return requests.post(
-         "https://api.mailgun.net/v2/lists/dev@samples.mailgun.org/members.json",
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'),
+         "https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members.json",
+         auth=('api', 'YOUR_API_KEY'),
          data={'upsert': True,
                'members': '[{"address": "Alice <alice@example.com>", "vars": {"age": 26}},{"name": "Bob", "address": "bob@example.com", "vars": {"age": 34}}]')
 
 .. code-block:: rb
 
  def add_list_member
-   RestClient.post("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0" \
-                   "@api.mailgun.net/v2/lists/dev@samples.mailgun.org/members.json",
+   RestClient.post("https://api:YOUR_API_KEY" \
+                   "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members.json",
                    :upsert => true,
                    :members => '[{"address": "Alice <alice@example.com>", "vars": {"age": 26}},{"name": "Bob", "address": "bob@example.com", "vars": {"age": 34}}]')
  end
@@ -63,10 +63,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}/members.json";
- 	request.AddParameter("list", "dev@samples.mailgun.org", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("members", "[{"address": "Alice <alice@example.com>", "vars": {"age": 26}},{"name": "Bob", "address": "bob@example.com", "vars": {"age": 34}}]");
  	request.AddParameter("upsert", true);
   	request.Method = Method.POST;
@@ -77,7 +77,7 @@
 
  func AddListMembers(domain, apiKey string) error {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.CreateMemberList(nil, "dev@samples.mailgun.org", []interface{}{
+   return mg.CreateMemberList(nil, "dev@YOUR_DOMAIN_NAME", []interface{}{
      mailgun.Member{
        Address:    "alice@example.com",
        Name:       "Alice's debugging account",

--- a/source/samples/add-list-members.rst
+++ b/source/samples/add-list-members.rst
@@ -2,7 +2,7 @@
 .. code-block:: bash
 
     curl -s --user 'api:YOUR_API_KEY' \
-	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members.json \
+	https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members.json \
 	-F upsert=true \
 	-F members='[{"address": "Alice <alice@example.com>", "vars": {"age": 26}},{"name": "Bob", "address": "bob@example.com", "vars": {"age": 34}}]'
 
@@ -14,7 +14,7 @@
  			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@YOUR_DOMAIN_NAME/members.json");
+ 				"LIST@YOUR_DOMAIN_NAME/members.json");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("members", "[{"address": "Alice <alice@example.com>", "vars": {"age": 26}},{"name": "Bob", "address": "bob@example.com", "vars": {"age": 34}}]");
  	formData.add("upsert", true);
@@ -30,7 +30,7 @@
 
   # Instantiate the client.
   $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'dev@YOUR_DOMAIN_NAME';
+  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->post("lists/$listAddress/members.json", array(
@@ -42,7 +42,7 @@
 
  def add_list_member():
      return requests.post(
-         "https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members.json",
+         "https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members.json",
          auth=('api', 'YOUR_API_KEY'),
          data={'upsert': True,
                'members': '[{"address": "Alice <alice@example.com>", "vars": {"age": 26}},{"name": "Bob", "address": "bob@example.com", "vars": {"age": 34}}]')
@@ -51,7 +51,7 @@
 
  def add_list_member
    RestClient.post("https://api:YOUR_API_KEY" \
-                   "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members.json",
+                   "@api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members.json",
                    :upsert => true,
                    :members => '[{"address": "Alice <alice@example.com>", "vars": {"age": 26}},{"name": "Bob", "address": "bob@example.com", "vars": {"age": 34}}]')
  end
@@ -66,7 +66,7 @@
  		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}/members.json";
- 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "LIST@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("members", "[{"address": "Alice <alice@example.com>", "vars": {"age": 26}},{"name": "Bob", "address": "bob@example.com", "vars": {"age": 34}}]");
  	request.AddParameter("upsert", true);
   	request.Method = Method.POST;
@@ -77,7 +77,7 @@
 
  func AddListMembers(domain, apiKey string) error {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.CreateMemberList(nil, "dev@YOUR_DOMAIN_NAME", []interface{}{
+   return mg.CreateMemberList(nil, "LIST@YOUR_DOMAIN_NAME", []interface{}{
      mailgun.Member{
        Address:    "alice@example.com",
        Name:       "Alice's debugging account",

--- a/source/samples/add-unsubscribe-all.rst
+++ b/source/samples/add-unsubscribe-all.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/unsubscribes \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/unsubscribes \
 	-F address='bob@example.com' \
 	-F tag='*'
 
@@ -11,9 +11,9 @@
  public static ClientResponse UnsubscribeFromAll() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/unsubscribes");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("address", "bob@example.com");
@@ -29,8 +29,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->post("$domain/unsubscribes", array(
@@ -42,15 +42,15 @@
 
  def unsubscribe_from_all():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/unsubscribes",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/unsubscribes",
+         auth=("api", "YOUR_API_KEY"),
          data={'address':'bob@example.com', 'tag': '*'})
 
 .. code-block:: rb
 
  def unsubscribe_from_all
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/unsubscribes",
+   RestClient.post "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/unsubscribes",
    :address => 'bob@example.com',
    :tag => '*'
  end
@@ -62,11 +62,11 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "{domain}/unsubscribes";
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("address", "bob@example.com");
  	request.AddParameter("tag", "*");
  	request.Method = Method.POST;

--- a/source/samples/add-unsubscribe-tag.rst
+++ b/source/samples/add-unsubscribe-tag.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/unsubscribes \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/unsubscribes \
 	-F address='bob@example.com' \
 	-F tag='tag1'
 
@@ -11,9 +11,9 @@
  public static ClientResponse UnsubscribeFromTag() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/unsubscribes");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("address", "bob@example.com");
@@ -29,8 +29,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->post("$domain/unsubscribes", array(
@@ -42,15 +42,15 @@
 
  def unsubscribe_from_tag():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/unsubscribes",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/unsubscribes",
+         auth=("api", "YOUR_API_KEY"),
          data={'address':'bob@example.com', 'tag': 'tag1'})
 
 .. code-block:: rb
 
  def unsubscribe_from_tag
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/unsubscribes",
+   RestClient.post "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/unsubscribes",
    :address => 'bob@example.com',
    :tag => 'tag1'
  end
@@ -62,11 +62,11 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "{domain}/unsubscribes";
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("address", "bob@example.com");
  	request.AddParameter("tag", "tag1");
  	request.Method = Method.POST;

--- a/source/samples/add-webhook.rst
+++ b/source/samples/add-webhook.rst
@@ -1,7 +1,7 @@
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/domains/samples.mailgun.org/webhooks \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks \
 	-F id='click' \
 	-F url='http://bin.mailgun.net/8de4a9c4'
 
@@ -10,9 +10,9 @@
  public static ClientResponse AddDomain() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/domains/samples.mailgun.org/webhooks");
+ 		client.resource("https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("id", "click");
  	formData.add("url", "http://bin.mailgun.net/8de4a9c4");
@@ -27,8 +27,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->post("domains/$domain/webhooks", array(
@@ -40,15 +40,15 @@
 
  def add_domain():
      return requests.post(
-         "https://api.mailgun.net/v2/domains/samples.mailgun.org/webhooks",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks",
+         auth=("api", "YOUR_API_KEY"),
          data={'id':'click', 'url':'http://bin.mailgun.net/8de4a9c4'})
 
 .. code-block:: rb
 
  def add_domain
-   RestClient.post("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-                   "@api.mailgun.net/v2/domains/samples.mailgun.org/webhooks",
+   RestClient.post("https://api:YOUR_API_KEY"\
+                   "@api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks",
                    :id => 'click',
                    :url => 'http://bin.mailgun.net/8de4a9c4')
  end
@@ -60,9 +60,9 @@
  	client.BaseUrl = "https://api.mailgun.net/v2/";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
- 	request.Resource = "domains/samples.mailgun.org/webhooks";
+ 	request.Resource = "domains/YOUR_DOMAIN_NAME/webhooks";
  	request.AddParameter("id", "click");
  	request.AddParameter("url", "http://bin.mailgun.net/8de4a9c4");
  	request.Method = Method.POST;

--- a/source/samples/change-mailbox-password.rst
+++ b/source/samples/change-mailbox-password.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -X PUT \
-	https://api.mailgun.net/v2/samples.mailgun.org/mailboxes/alice \
+    curl -s --user 'api:YOUR_API_KEY' -X PUT \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/mailboxes/alice \
 	-F password='abc123'
 
 .. code-block:: java
@@ -10,9 +10,9 @@
  public static ClientResponse ChangeMailboxPassword() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/mailboxes/alice");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("password", "supersecret");
@@ -27,8 +27,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $mailbox = 'alice';
 
   # Issue the call to the client.
@@ -40,15 +40,15 @@
 
  def change_mailbox_password():
      return requests.put(
-         "https://api.mailgun.net/v2/samples.mailgun.org/mailboxes/alice",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/mailboxes/alice",
+         auth=("api", "YOUR_API_KEY"),
          data={"password": "supersecret"})
 
 .. code-block:: rb
 
  def change_mailbox_password
-   RestClient.put "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/mailboxes/alice",
+   RestClient.put "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/mailboxes/alice",
    :password => "supersecret"
  end
 
@@ -59,10 +59,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/mailboxes/{login}";
  	request.AddUrlSegment("login", "alice");
  	request.AddParameter("password", "supersecret");

--- a/source/samples/change-pwd-credentials.rst
+++ b/source/samples/change-pwd-credentials.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -X PUT \
-	https://api.mailgun.net/v2/samples.mailgun.org/credentials/alice \
+    curl -s --user 'api:YOUR_API_KEY' -X PUT \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/credentials/alice \
 	-F password='abc123'
 
 .. code-block:: java
@@ -10,9 +10,9 @@
  public static ClientResponse ChangeCredentialPassword() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/credentials/alice");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("password", "supersecret");
@@ -27,8 +27,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $login= 'alice';
 
   # Issue the call to the client.
@@ -40,15 +40,15 @@
 
  def change_credential_password():
      return requests.put(
-         "https://api.mailgun.net/v2/samples.mailgun.org/credentials/alice",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/credentials/alice",
+         auth=("api", "YOUR_API_KEY"),
          data={"password": "supersecret"})
 
 .. code-block:: rb
 
  def change_credential_password
-   RestClient.put "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/credentials/alice",
+   RestClient.put "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/credentials/alice",
    :password => "supersecret"
  end
 
@@ -59,10 +59,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/credentials/{username}";
  	request.AddUrlSegment("username", "alice");
  	request.AddParameter("password", "supersecret");

--- a/source/samples/create-campaign.rst
+++ b/source/samples/create-campaign.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/campaigns \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns \
 	-F name='Newsletter' \
 	-F id='my_campaign_id'
 
@@ -11,9 +11,9 @@
  public static ClientResponse CreateCampaign() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/campaigns");
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("name", "Newsletter");
  	formData.add("id", "my_campaign_id");
@@ -28,8 +28,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->post("$domain/campaigns", array(
@@ -40,16 +40,16 @@
 
  def create_campaign():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/campaigns",
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns",
+         auth=('api', 'YOUR_API_KEY'),
          data={'name': 'Newsletter',
                'id': 'my_campaign_id'})
 
 .. code-block:: rb
 
  def create_campaign
-   RestClient.post("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0" \
-                   "@api.mailgun.net/v2/samples.mailgun.org/campaigns",
+   RestClient.post("https://api:YOUR_API_KEY" \
+                   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns",
                    :name => 'Newsletter',
                    :id => 'my_campaign_id') {
      |response, request, result| response
@@ -63,10 +63,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "{domain}/campaigns";
- 	request.AddParameter("domain", "samples.mailgun.org",
+ 	request.AddParameter("domain", "YOUR_DOMAIN_NAME",
  	                     ParameterType.UrlSegment);
  	request.AddParameter("name", "Newsletter");
  	request.AddParameter("id", "my_campaign_id");

--- a/source/samples/create-credentials.rst
+++ b/source/samples/create-credentials.rst
@@ -1,9 +1,9 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/domains/samples.mailgun.org/credentials \
-	-F login='alice@samples.mailgun.org' \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/credentials \
+	-F login='alice@YOUR_DOMAIN_NAME' \
 	-F password='supasecret'
 
 .. code-block:: java
@@ -11,12 +11,12 @@
  public static ClientResponse CreateCredentials() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/domains/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME" +
  				"/credentials");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
- 	formData.add("login", "alice@samples.mailgun.org");
+ 	formData.add("login", "alice@YOUR_DOMAIN_NAME");
  	formData.add("password", "secret");
  	return webResource.type(MediaType.APPLICATION_FORM_URLENCODED).
  		post(ClientResponse.class, formData);
@@ -29,12 +29,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->post("domains/$domain/credentials", array(
-      'login'    => 'alice@samples.mailgun.org',
+      'login'    => 'alice@YOUR_DOMAIN_NAME',
       'password' => 'secret'
   ));
 
@@ -42,17 +42,17 @@
 
  def create_credentials():
      return requests.post(
-         "https://api.mailgun.net/v2/domains/samples.mailgun.org/credentials",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
-         data={"login": "alice@samples.mailgun.org",
+         "https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/credentials",
+         auth=("api", "YOUR_API_KEY"),
+         data={"login": "alice@YOUR_DOMAIN_NAME",
                "password": "secret"})
 
 .. code-block:: rb
 
  def create_credentials
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/domains/samples.mailgun.org/credentials",
-   :login => "alice@samples.mailgun.org",
+   RestClient.post "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/credentials",
+   :login => "alice@YOUR_DOMAIN_NAME",
    :password => "secret"
  end
 
@@ -63,12 +63,12 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "domains/{domain}/credentials";
- 	request.AddParameter("login", "alice@samples.mailgun.org");
+ 	request.AddParameter("login", "alice@YOUR_DOMAIN_NAME");
  	request.AddParameter("password", "secret");
  	request.Method = Method.POST;
  	return client.Execute(request);
@@ -78,5 +78,5 @@
 
  func CreateCredential(domain, apiKey string) error {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.CreateCredential("alice@samples.mailgun.org", "secret")
+   return mg.CreateCredential("alice@YOUR_DOMAIN_NAME", "secret")
  }

--- a/source/samples/create-domain.rst
+++ b/source/samples/create-domain.rst
@@ -1,9 +1,9 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
+    curl -s --user 'api:YOUR_API_KEY' \
     https://api.mailgun.net/v2/domains \
-    -F name='samples.mailgun.org' \
+    -F name='YOUR_DOMAIN_NAME' \
     -F smtp_password='supasecret'
 
 .. code-block:: java
@@ -11,11 +11,11 @@
  public static ClientResponse CreateDomain() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/domains");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
- 	formData.add("name", "samples.mailgun.org");
+ 	formData.add("name", "YOUR_DOMAIN_NAME");
  	formData.add("smtp_password", "supasecret");
  	return webResource.type(MediaType.APPLICATION_FORM_URLENCODED).
  		post(ClientResponse.class, formData);
@@ -28,7 +28,7 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
+  $mgClient = new Mailgun('YOUR_API_KEY');
 
   # Issue the call to the client.
   $result = $mgClient->post("domains", array(
@@ -41,17 +41,17 @@
  def create_domain():
      return requests.post(
          "https://api.mailgun.net/v2/domains",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
-         data={"name": "samples.mailgun.org",
+         auth=("api", "YOUR_API_KEY"),
+         data={"name": "YOUR_DOMAIN_NAME",
                "smtp_password": "supasecret"})
 
 .. code-block:: rb
 
  def create_domain
    data = Multimap.new
-   data[:name] = "samples.mailgun.org"
+   data[:name] = "YOUR_DOMAIN_NAME"
    data[:smtp_password] = "supasecret"
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
+   RestClient.post "https://api:YOUR_API_KEY"\
    "@api.mailgun.net/v2/domains", data
  end
 
@@ -62,7 +62,7 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "domains";
  	request.AddParameter("name", "supasecret");
@@ -75,5 +75,5 @@
 
  func CreateDomain(domain, apiKey string) error {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.CreateDomain("samples.mailgun.org", "supersecretpw", mailgun.Tag, false)
+   return mg.CreateDomain("YOUR_DOMAIN_NAME", "supersecretpw", mailgun.Tag, false)
  }

--- a/source/samples/create-mailbox.rst
+++ b/source/samples/create-mailbox.rst
@@ -1,9 +1,9 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/mailboxes \
-	-F mailbox='alice@samples.mailgun.org' \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/mailboxes \
+	-F mailbox='alice@YOUR_DOMAIN_NAME' \
 	-F password='supasecret'
 
 .. code-block:: java
@@ -11,12 +11,12 @@
  public static ClientResponse CreateMailbox() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/mailboxes");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
- 	formData.add("mailbox", "alice@samples.mailgun.org");
+ 	formData.add("mailbox", "alice@YOUR_DOMAIN_NAME");
  	formData.add("password", "secret");
  	return webResource.type(MediaType.APPLICATION_FORM_URLENCODED).
  		post(ClientResponse.class, formData);
@@ -29,12 +29,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->post("$domain/mailboxes", array(
-      'mailbox'  => 'alice@samples.mailgun.org',
+      'mailbox'  => 'alice@YOUR_DOMAIN_NAME',
       'password' => 'secret'
   ));
 
@@ -42,17 +42,17 @@
 
  def create_mailbox():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/mailboxes",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
-         data={"mailbox": "alice@samples.mailgun.org",
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/mailboxes",
+         auth=("api", "YOUR_API_KEY"),
+         data={"mailbox": "alice@YOUR_DOMAIN_NAME",
                "password": "secret"})
 
 .. code-block:: rb
 
  def create_mailbox
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/mailboxes",
-   :mailbox => "alice@samples.mailgun.org",
+   RestClient.post "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/mailboxes",
+   :mailbox => "alice@YOUR_DOMAIN_NAME",
    :password => "secret"
  end
 
@@ -63,12 +63,12 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/mailboxes";
- 	request.AddParameter("mailbox", "alice@samples.mailgun.org");
+ 	request.AddParameter("mailbox", "alice@YOUR_DOMAIN_NAME");
  	request.AddParameter("password", "secret");
  	request.Method = Method.POST;
  	return client.Execute(request);

--- a/source/samples/create-mailing-list.rst
+++ b/source/samples/create-mailing-list.rst
@@ -3,7 +3,7 @@
 
     curl -s --user 'api:YOUR_API_KEY' \
 	https://api.mailgun.net/v2/lists \
-	-F address='dev@YOUR_DOMAIN_NAME' \
+	-F address='LIST@YOUR_DOMAIN_NAME' \
 	-F description='Mailgun developers list'
 
 .. code-block:: java
@@ -15,7 +15,7 @@
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
- 	formData.add("address", "dev@YOUR_DOMAIN_NAME");
+ 	formData.add("address", "LIST@YOUR_DOMAIN_NAME");
  	formData.add("description", "Mailgun developers list");
  	return webResource.type(MediaType.APPLICATION_FORM_URLENCODED).
  		post(ClientResponse.class, formData);
@@ -33,7 +33,7 @@
 
   # Issue the call to the client.
   $result = $mgClient->post("lists", array(
-      'address'     => 'dev@YOUR_DOMAIN_NAME',
+      'address'     => 'LIST@YOUR_DOMAIN_NAME',
       'description' => 'Mailgun Dev List'
   ));
 
@@ -43,7 +43,7 @@
      return requests.post(
          "https://api.mailgun.net/v2/lists",
          auth=('api', 'YOUR_API_KEY'),
-         data={'address': 'dev@YOUR_DOMAIN_NAME',
+         data={'address': 'LIST@YOUR_DOMAIN_NAME',
                'description': "Mailgun developers list"})
 
 .. code-block:: rb
@@ -51,7 +51,7 @@
  def create_mailing_list
    RestClient.post("https://api:YOUR_API_KEY" \
                    "@api.mailgun.net/v2/lists",
-                   :address => 'dev@YOUR_DOMAIN_NAME',
+                   :address => 'LIST@YOUR_DOMAIN_NAME',
                    :description => "Mailgun developers list")
  end
 
@@ -66,7 +66,7 @@
  		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists";
- 	request.AddParameter("address", "dev@YOUR_DOMAIN_NAME");
+ 	request.AddParameter("address", "LIST@YOUR_DOMAIN_NAME");
  	request.AddParameter("description", "Mailgun developers list");
  	request.Method = Method.POST;
  	return client.Execute(request);
@@ -77,7 +77,7 @@
   func CreateMailingList(domain, apiKey string) (mailgun.List, error) {
     mg := mailgun.NewMailgun(domain, apiKey, "")
     protoList := mailgun.List{
-      Address:     "dev@YOUR_DOMAIN_NAME",
+      Address:     "LIST@YOUR_DOMAIN_NAME",
       Name:        "dev",
       Description: "Mailgun developers list.",
       AccessLevel: mailgun.Members,

--- a/source/samples/create-mailing-list.rst
+++ b/source/samples/create-mailing-list.rst
@@ -1,9 +1,9 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
+    curl -s --user 'api:YOUR_API_KEY' \
 	https://api.mailgun.net/v2/lists \
-	-F address='dev@samples.mailgun.org' \
+	-F address='dev@YOUR_DOMAIN_NAME' \
 	-F description='Mailgun developers list'
 
 .. code-block:: java
@@ -11,11 +11,11 @@
  public static ClientResponse CreateMailingList() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
- 	formData.add("address", "dev@samples.mailgun.org");
+ 	formData.add("address", "dev@YOUR_DOMAIN_NAME");
  	formData.add("description", "Mailgun developers list");
  	return webResource.type(MediaType.APPLICATION_FORM_URLENCODED).
  		post(ClientResponse.class, formData);
@@ -29,11 +29,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
+  $mgClient = new Mailgun('YOUR_API_KEY');
 
   # Issue the call to the client.
   $result = $mgClient->post("lists", array(
-      'address'     => 'dev@samples.mailgun.org',
+      'address'     => 'dev@YOUR_DOMAIN_NAME',
       'description' => 'Mailgun Dev List'
   ));
 
@@ -42,16 +42,16 @@
  def create_mailing_list():
      return requests.post(
          "https://api.mailgun.net/v2/lists",
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'),
-         data={'address': 'dev@samples.mailgun.org',
+         auth=('api', 'YOUR_API_KEY'),
+         data={'address': 'dev@YOUR_DOMAIN_NAME',
                'description': "Mailgun developers list"})
 
 .. code-block:: rb
 
  def create_mailing_list
-   RestClient.post("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0" \
+   RestClient.post("https://api:YOUR_API_KEY" \
                    "@api.mailgun.net/v2/lists",
-                   :address => 'dev@samples.mailgun.org',
+                   :address => 'dev@YOUR_DOMAIN_NAME',
                    :description => "Mailgun developers list")
  end
 
@@ -63,10 +63,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists";
- 	request.AddParameter("address", "dev@samples.mailgun.org");
+ 	request.AddParameter("address", "dev@YOUR_DOMAIN_NAME");
  	request.AddParameter("description", "Mailgun developers list");
  	request.Method = Method.POST;
  	return client.Execute(request);
@@ -77,7 +77,7 @@
   func CreateMailingList(domain, apiKey string) (mailgun.List, error) {
     mg := mailgun.NewMailgun(domain, apiKey, "")
     protoList := mailgun.List{
-      Address:     "dev@samples.mailgun.org",
+      Address:     "dev@YOUR_DOMAIN_NAME",
       Name:        "dev",
       Description: "Mailgun developers list.",
       AccessLevel: mailgun.Members,

--- a/source/samples/create-route.rst
+++ b/source/samples/create-route.rst
@@ -1,10 +1,10 @@
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
+    curl -s --user 'api:YOUR_API_KEY' \
 	https://api.mailgun.net/v2/routes \
 	-F priority=0 \
 	-F description='Sample route' \
-	-F expression='match_recipient(".*@samples.mailgun.org")' \
+	-F expression='match_recipient(".*@YOUR_DOMAIN_NAME")' \
 	-F action='forward("http://myhost.com/messages/")' \
 	-F action='stop()'
 
@@ -13,13 +13,13 @@
  public static ClientResponse CreateRoute() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/routes");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("priority", 0);
  	formData.add("description", "Sample route");
- 	formData.add("expression", "match_recipient('.*@samples.mailgun.org')");
+ 	formData.add("expression", "match_recipient('.*@YOUR_DOMAIN_NAME')");
  	formData.add("action", "forward('http://myhost.com/messages/')");
  	formData.add("action", "stop()");
  	return webResource.type(MediaType.APPLICATION_FORM_URLENCODED).
@@ -33,12 +33,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
+  $mgClient = new Mailgun('YOUR_API_KEY');
 
   # Issue the call to the client.
   $result = $mgClient->post("routes", array(
       'priority'    => 0,
-      'expression'  => 'match_recipient(".*@samples.mailgun.org")',
+      'expression'  => 'match_recipient(".*@YOUR_DOMAIN_NAME")',
       'action'      => array('forward("http://host.com/messages")', 'stop()'),
       'description' => 'Sample route'
   ));
@@ -48,10 +48,10 @@
  def create_route():
      return requests.post(
          "https://api.mailgun.net/v2/routes",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         auth=("api", "YOUR_API_KEY"),
          data={"priority": 0,
                "description": "Sample route",
-               "expression": "match_recipient('.*@samples.mailgun.org')",
+               "expression": "match_recipient('.*@YOUR_DOMAIN_NAME')",
                "action": ["forward('http://myhost.com/messages/')", "stop()"]})
 
 .. code-block:: rb
@@ -60,10 +60,10 @@
    data = Multimap.new
    data[:priority] = 0
    data[:description] = "Sample route"
-   data[:expression] = "match_recipient('.*@samples.mailgun.org')"
+   data[:expression] = "match_recipient('.*@YOUR_DOMAIN_NAME')"
    data[:action] = "forward('http://myhost.com/messages/')"
    data[:action] = "stop()"
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
+   RestClient.post "https://api:YOUR_API_KEY"\
    "@api.mailgun.net/v2/routes", data
  end
 
@@ -74,13 +74,13 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "routes";
  	request.AddParameter("priority", 0);
  	request.AddParameter("description", "Sample route");
  	request.AddParameter("expression",
- 	                     "match_recipient('.*@samples.mailgun.org')");
+ 	                     "match_recipient('.*@YOUR_DOMAIN_NAME')");
  	request.AddParameter("action",
  	                     "forward('http://myhost.com/messages/')");
  	request.AddParameter("action", "stop()");
@@ -95,7 +95,7 @@
    return mg.CreateRoute(mailgun.Route{
      Priority:    1,
      Description: "Sample Route",
-     Expression:  "match_recipient(\".*@samples.mailgun.org\")",
+     Expression:  "match_recipient(\".*@YOUR_DOMAIN_NAME\")",
      Actions: []string{
        "forward(\"http://example.com/messages/\")",
        "stop()",

--- a/source/samples/delete-credentials.rst
+++ b/source/samples/delete-credentials.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
- curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -X DELETE \
-     https://api.mailgun.net/v2/domains/samples.mailgun.org/credentials/alice
+ curl -s --user 'api:YOUR_API_KEY' -X DELETE \
+     https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/credentials/alice
 
 .. code-block:: java
 
  public static ClientResponse DeleteCredentials() {
   Client client = Client.create();
   client.addFilter(new HTTPBasicAuthFilter("api",
-      "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+      "YOUR_API_KEY"));
   WebResource webResource =
-    client.resource("https://api.mailgun.net/v2/domains/samples.mailgun.org" +
+    client.resource("https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME" +
         "/credentials/alice");
   return webResource.delete(ClientResponse.class);
  }
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $login = 'alice';
 
   # Issue the call to the client.
@@ -34,14 +34,14 @@
 
  def delete_credentials():
      return requests.delete(
-         "https://api.mailgun.net/v2/domains/samples.mailgun.org/credentials/alice",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/credentials/alice",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def delete_credentials
-   RestClient.delete "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/domains/samples.mailgun.org/credentials/alice"
+   RestClient.delete "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/credentials/alice"
  end
 
 .. code-block:: csharp
@@ -51,10 +51,10 @@
   client.BaseUrl = "https://api.mailgun.net/v2";
   client.Authenticator =
     new HttpBasicAuthenticator("api",
-                               "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+                               "YOUR_API_KEY");
   RestRequest request = new RestRequest();
   request.AddParameter("domain",
-                       "samples.mailgun.org", ParameterType.UrlSegment);
+                       "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
   request.Resource = "domains/{domain}/credentials/{login}";
   request.AddUrlSegment("login", "alice");
   request.Method = Method.DELETE;

--- a/source/samples/delete-domain.rst
+++ b/source/samples/delete-domain.rst
@@ -1,7 +1,7 @@
 
 .. code-block:: bash
 
- curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -X DELETE \
+ curl -s --user 'api:YOUR_API_KEY' -X DELETE \
      https://api.mailgun.net/v2/domains/example.mailgun.org
 
 .. code-block:: java
@@ -9,7 +9,7 @@
  public static ClientResponse DeleteDomain() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2" +
  				"/domains/example.mailgun.org");
@@ -23,7 +23,7 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
+  $mgClient = new Mailgun('YOUR_API_KEY');
   $domain = 'example.mailgun.org';
 
   # Issue the call to the client.
@@ -34,12 +34,12 @@
  def delete_domain():
      return requests.delete(
          "https://api.mailgun.net/v2/domains/example.mailgun.org",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def delete_domain
-   RestClient.delete "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
+   RestClient.delete "https://api:YOUR_API_KEY"\
    "@api.mailgun.net/v2/domains/example.mailgun.org"
  end
 
@@ -50,7 +50,7 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "/domains/{name}";
  	request.AddUrlSegment("name", "example.mailgun.org");

--- a/source/samples/delete-mailbox.rst
+++ b/source/samples/delete-mailbox.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
- curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -X DELETE \
-     https://api.mailgun.net/v2/samples.mailgun.org/mailboxes/alice
+ curl -s --user 'api:YOUR_API_KEY' -X DELETE \
+     https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/mailboxes/alice
 
 .. code-block:: java
 
  public static ClientResponse DeleteMailbox() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/mailboxes/alice");
  	return webResource.delete(ClientResponse.class);
  }
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $mailbox = 'alice';
 
   # Issue the call to the client.
@@ -34,14 +34,14 @@
 
  def delete_mailbox():
      return requests.delete(
-         "https://api.mailgun.net/v2/samples.mailgun.org/mailboxes/alice",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/mailboxes/alice",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def delete_mailbox
-   RestClient.delete "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/mailboxes/alice"
+   RestClient.delete "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/mailboxes/alice"
  end
 
 .. code-block:: csharp
@@ -51,10 +51,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/mailboxes/{username}";
  	request.AddUrlSegment("username", "alice");
  	request.Method = Method.DELETE;

--- a/source/samples/delete-tag.rst
+++ b/source/samples/delete-tag.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
- curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -X DELETE \
-     https://api.mailgun.net/v2/samples.mailgun.org/tags/newsletter
+ curl -s --user 'api:YOUR_API_KEY' -X DELETE \
+     https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/tags/newsletter
 
 .. code-block:: java
 
  public static ClientResponse DeleteTag() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/tags/newsletter");
  	return webResource.delete(ClientResponse.class);
  }
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $tag = 'myexampletag';
 
   # Issue the call to the client.
@@ -34,14 +34,14 @@
 
  def delete_tag():
      return requests.delete(
-         "https://api.mailgun.net/v2/samples.mailgun.org/tags/newsletter",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/tags/newsletter",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def delete_tag
-   RestClient.delete "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/tag/newsletter"
+   RestClient.delete "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/tag/newsletter"
  end
 
 .. code-block:: csharp
@@ -51,10 +51,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/tags/{tag}";
  	request.AddUrlSegment("tag", "newsletter");
  	request.Method = Method.DELETE;

--- a/source/samples/delete-webhook.rst
+++ b/source/samples/delete-webhook.rst
@@ -1,18 +1,18 @@
 
 .. code-block:: bash
 
- curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -X DELETE \
-     https://api.mailgun.net/v2/domains/samples.mailgun.org/webhooks/click
+ curl -s --user 'api:YOUR_API_KEY' -X DELETE \
+     https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks/click
 
 .. code-block:: java
 
  public static ClientResponse DeleteDomain() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2" +
- 				"/domains/samples.mailgun.org/webhooks/click");
+ 				"/domains/YOUR_DOMAIN_NAME/webhooks/click");
  	return webResource.delete(ClientResponse.class);
  }
 
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->delete("$domain/webhooks/click");
@@ -33,14 +33,14 @@
 
  def delete_domain():
      return requests.delete(
-         "https://api.mailgun.net/v2/domains/samples.mailgun.org/webhooks/click",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks/click",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def delete_domain
-   RestClient.delete "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/domains/samples.mailgun.org/webhooks/click"
+   RestClient.delete "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks/click"
  end
 
 .. code-block:: csharp
@@ -50,10 +50,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "/domains/{name}/webhooks/click";
- 	request.AddUrlSegment("name", "samples.mailgun.org");
+ 	request.AddUrlSegment("name", "YOUR_DOMAIN_NAME");
  	request.Method = Method.DELETE;
  	return client.Execute(request);
  }

--- a/source/samples/events-date-time-recipient.rst
+++ b/source/samples/events-date-time-recipient.rst
@@ -1,7 +1,7 @@
 .. code-block:: bash
 
-  curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-        https://api.mailgun.net/v2/samples.mailgun.org/events \
+  curl -s --user 'api:YOUR_API_KEY' -G \
+        https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/events \
         --data-urlencode begin='Fri, 3 May 2013 09:00:00 -0000' \
         --data-urlencode ascending=yes \
         --data-urlencode limit=25 \
@@ -13,10 +13,10 @@
  public static ClientResponse GetLogs() {
   Client client = new Client();
   client.addFilter(new HTTPBasicAuthFilter("api",
-      "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+      "YOUR_API_KEY"));
   WebResource webResource =
       client.resource("
-          https://api.mailgun.net/v2/samples.mailgun.org/events");
+          https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/events");
   MultivaluedMapImpl queryParams = new MultivaluedMapImpl();
   queryParams.add("begin", 50);
   queryParams.add("ascending", "yes");
@@ -34,8 +34,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $queryString = array(
       'begin'        => 'Fri, 3 May 2013 09:00:00 -0000',
       'ascending'    => 'yes',
@@ -51,8 +51,8 @@
 
  def get_logs():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/events",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/events",
+         auth=("api", "YOUR_API_KEY"),
          params={"begin"       : "Fri, 3 May 2013 09:00:00 -0000",
                  "ascending"   : "yes",
                  "limit"       :  25,
@@ -62,8 +62,8 @@
 .. code-block:: rb
 
  def get_logs
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/events", 
+   RestClient.get "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/events", 
     :params => {
      :'begin'       => 'Fri, 3 May 2013 09:00:00 -0000',
      :'ascending'   => 'yes',
@@ -80,10 +80,10 @@
     client.BaseUrl = "https://api.mailgun.net/v2";
     client.Authenticator =
         new HttpBasicAuthenticator("api",
-            "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+            "YOUR_API_KEY");
     RestRequest request = new RestRequest();
     request.AddParameter("domain",
-        "samples.mailgun.org", ParameterType.UrlSegment);
+        "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
     request.Resource = "{domain}/events";
     request.AddParameter("begin", "Fri, 3 May 2013 09:00:00 -0000");
     request.AddParameter("ascending", "yes");

--- a/source/samples/events-failure.rst
+++ b/source/samples/events-failure.rst
@@ -1,7 +1,7 @@
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-        https://api.mailgun.net/v2/samples.mailgun.org/events \
+    curl -s --user 'api:YOUR_API_KEY' -G \
+        https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/events \
         --data-urlencode event='rejected OR failed'
 
 .. code-block:: java
@@ -9,10 +9,10 @@
  public static ClientResponse GetLogs() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("
-        https://api.mailgun.net/v2/samples.mailgun.org/events");
+        https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/events");
  	MultivaluedMapImpl queryParams = new MultivaluedMapImpl();
  	queryParams.add("event", "rejected OR failed");
  	return webResource.queryParams(queryParams).get(ClientResponse.class);
@@ -25,8 +25,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $queryString = array('event' => 'rejected OR failed');
 
   # Make the call to the client.
@@ -36,15 +36,15 @@
 
  def get_logs():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/events",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/events",
+         auth=("api", "YOUR_API_KEY"),
          params={"event" : "rejected OR failed"})
 
 .. code-block:: rb
 
  def get_logs
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/events", 
+   RestClient.get "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/events", 
    :params => {
      :"event" => 'rejected OR failed'
    }
@@ -57,10 +57,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/events";
  	request.AddParameter("event", "rejected OR failed");
  	return client.Execute(request);

--- a/source/samples/events-pagination.rst
+++ b/source/samples/events-pagination.rst
@@ -1,17 +1,17 @@
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-        https://api.mailgun.net/v2/samples.mailgun.org/events/W3siYSI6IGZhbHNlLC
+    curl -s --user 'api:YOUR_API_KEY' -G \
+        https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/events/W3siYSI6IGZhbHNlLC
 
 .. code-block:: java
 
  public static ClientResponse GetLogs() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("
-        https://api.mailgun.net/v2/samples.mailgun.org/events/W3siYSI6IGZhbHNlLC");
+        https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/events/W3siYSI6IGZhbHNlLC");
  	return webResource.get(ClientResponse.class);
  }
 
@@ -22,8 +22,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $nextPage = 'W3siYSI6IGZhbHNlLC';
 
   # Make the call to the client.
@@ -33,14 +33,14 @@
 
  def get_logs():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/events/W3siYSI6IGZhbHNlLC",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/events/W3siYSI6IGZhbHNlLC",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def get_logs
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/events/W3siYSI6IGZhbHNlLC"}
+   RestClient.get "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/events/W3siYSI6IGZhbHNlLC"}
  end
 
 .. code-block:: csharp
@@ -50,10 +50,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/events/W3siYSI6IGZhbHNlLC";
  	return client.Execute(request);
  }

--- a/source/samples/events-traversal.rst
+++ b/source/samples/events-traversal.rst
@@ -1,17 +1,17 @@
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-        https://api.mailgun.net/v2/samples.mailgun.org/events
+    curl -s --user 'api:YOUR_API_KEY' -G \
+        https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/events
 
 .. code-block:: java
 
  public static ClientResponse GetLogs() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("
-        https://api.mailgun.net/v2/samples.mailgun.org/events");
+        https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/events");
  	return webResource.get(ClientResponse.class);
  }
 
@@ -22,8 +22,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Make the call to the client.
   $result = $mgClient->get("$domain/events");
@@ -32,14 +32,14 @@
 
  def get_logs():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/events",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/events",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def get_logs
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/events"}
+   RestClient.get "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/events"}
  end
 
 .. code-block:: csharp
@@ -49,10 +49,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/events";
  	return client.Execute(request);
  }

--- a/source/samples/get-bounce.rst
+++ b/source/samples/get-bounce.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/samples.mailgun.org/bounces/foo@bar.com
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/bounces/foo@bar.com
 
 .. code-block:: java
 
  public static ClientResponse GetBounce() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/" +
  				"bounces/foo@bar.com");
  	return webResource.get(ClientResponse.class);
  }
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $bounce = 'bob@example.com';
 
   # Issue the call to the client.
@@ -34,14 +34,14 @@
 
  def get_bounce():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/bounces/foo@bar.com",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/bounces/foo@bar.com",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def get_bounce
-   RestClient.get("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-                  "@api.mailgun.net/v2/samples.mailgun.org/bounces"\
+   RestClient.get("https://api:YOUR_API_KEY"\
+                  "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/bounces"\
                   "/foo@bar.com"){|response, request, result| response }
  end
 
@@ -52,10 +52,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/bounces/foo@bar.com";
  	return client.Execute(request);
  }

--- a/source/samples/get-bounces.rst
+++ b/source/samples/get-bounces.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-      https://api.mailgun.net/v2/samples.mailgun.org/bounces \
+    curl -s --user 'api:YOUR_API_KEY' -G \
+      https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/bounces \
         -d skip=1 \
         -d limit=1
 
@@ -11,9 +11,9 @@
  public static ClientResponse GetBounces() {
   Client client = new Client();
   client.addFilter(new HTTPBasicAuthFilter("api",
-      "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+      "YOUR_API_KEY"));
   WebResource webResource =
-    client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+    client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
         "/bounces");
   return webResource.get(ClientResponse.class);
  }
@@ -25,8 +25,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("$domain/bounces", array('skip' => 0, 'limit' => 50));
@@ -35,14 +35,14 @@
 
  def get_bounces():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/bounces",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/bounces",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def get_bounces
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/bounces"
+   RestClient.get "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/bounces"
  end
 
 .. code-block:: csharp
@@ -52,10 +52,10 @@
   client.BaseUrl = "https://api.mailgun.net/v2";
   client.Authenticator =
     new HttpBasicAuthenticator("api",
-                               "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+                               "YOUR_API_KEY");
   RestRequest request = new RestRequest();
   request.AddParameter("domain",
-                       "samples.mailgun.org", ParameterType.UrlSegment);
+                       "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
   request.Resource = "{domain}/bounces";
   return client.Execute(request);
  }

--- a/source/samples/get-campaign-events.rst
+++ b/source/samples/get-campaign-events.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/samples.mailgun.org/campaigns/my_campaign_id/events?limit=2
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/my_campaign_id/events?limit=2
 
 .. code-block:: java
 
  public static ClientResponse GetEventsHistory() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/campaigns/my_campaign_id/events");
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/my_campaign_id/events");
  	MultivaluedMapImpl queryParams = new MultivaluedMapImpl();
  	queryParams.add("limit", 2);
  	return webResource.queryParams(queryParams).get(ClientResponse.class);
@@ -24,8 +24,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $campaignId = 'myexamplecampaign';
 
   # Make the call to the client.
@@ -38,14 +38,14 @@
 
  def get_events_history():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/campaigns/my_campaign_id/events?limit=2",
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/my_campaign_id/events?limit=2",
+         auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
  def get_events_history
-   RestClient.get("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-                  "@api.mailgun.net/v2/samples.mailgun.org/campaigns/"\
+   RestClient.get("https://api:YOUR_API_KEY"\
+                  "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/"\
                   "my_campaign_id/events?limit=2")
  end
 
@@ -56,10 +56,10 @@
      client.BaseUrl = "https://api.mailgun.net/v2";
      client.Authenticator =
 	new HttpBasicAuthenticator("api",
-	                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+	                           "YOUR_API_KEY");
      RestRequest request = new RestRequest();
      request.AddParameter("domain",
-                           "samples.mailgun.org", ParameterType.UrlSegment);
+                           "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
      request.Resource = "{domain}/campaigns/my_campaign_id/events";
      request.AddParameter("limit", 2);
      return client.Execute(request);

--- a/source/samples/get-campaign-recipient-history.rst
+++ b/source/samples/get-campaign-recipient-history.rst
@@ -1,18 +1,18 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
+    curl -s --user 'api:YOUR_API_KEY' -G \
 	-d "recipient=baz@example.com&limit=2" \
-	https://api.mailgun.net/v2/samples.mailgun.org/campaigns/my_campaign_id/events
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/my_campaign_id/events
 
 .. code-block:: java
 
  public static ClientResponse GetCampaignRecipientHistory() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/campaigns/my_campaign_id/events");
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/my_campaign_id/events");
  	MultivaluedMapImpl queryParams = new MultivaluedMapImpl();
  	queryParams.add("recipient", "baz@example.com");
  	queryParams.add("limit", 2);
@@ -26,8 +26,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $campaignId = 'myexamplecampaign';
 
   # Issue the call to the client.
@@ -40,15 +40,15 @@
 
  def get_campaign_recipient_history():
      return requests.get(
-         ("https://api.mailgun.net/v2/samples.mailgun.org/campaigns"
+         ("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns"
           "/my_campaign_id/events?recipient=baz@example.com&limit=2"),
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'))
+         auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
  def get_campaign_recipient_history
-   RestClient.get("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-                  "@api.mailgun.net/v2/samples.mailgun.org/campaigns/"\
+   RestClient.get("https://api:YOUR_API_KEY"\
+                  "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/"\
                   "my_campaign_id/events?recipient=baz@example.com&limit=2")
  end
 
@@ -59,11 +59,11 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "{domain}/campaigns/my_campaign_id/events";
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("recipient", "baz@example.com");
  	request.AddParameter("limit", 2);
  	return client.Execute(request);

--- a/source/samples/get-campaign-recipients-who-clicked.rst
+++ b/source/samples/get-campaign-recipients-who-clicked.rst
@@ -1,18 +1,18 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
+    curl -s --user 'api:YOUR_API_KEY' -G \
 	-d "groupby=recipient&limit=2" \
-	https://api.mailgun.net/v2/samples.mailgun.org/campaigns/my_campaign_id/clicks
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/my_campaign_id/clicks
 
 .. code-block:: java
 
  public static ClientResponse GetClicks() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/campaigns/my_campaign_id/clicks");
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/my_campaign_id/clicks");
  	MultivaluedMapImpl queryParams = new MultivaluedMapImpl();
                 queryParams.add("groupby", "recipient");
  	queryParams.add("limit", 2);
@@ -26,8 +26,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $campaignId = 'myexamplecampaign';
 
   # Issue the call to the client.
@@ -40,14 +40,14 @@
 
  def get_clicks():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/campaigns/my_campaign_id/clicks?groupby=recipient&limit=2",
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/my_campaign_id/clicks?groupby=recipient&limit=2",
+         auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
  def get_clicks
-   RestClient.get("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-                  "@api.mailgun.net/v2/samples.mailgun.org/campaigns/"\
+   RestClient.get("https://api:YOUR_API_KEY"\
+                  "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/"\
                   "my_campaign_id/clicks?groupby=recipient&limit=2")
  end
 
@@ -58,10 +58,10 @@
      client.BaseUrl = "https://api.mailgun.net/v2";
      client.Authenticator =
 	new HttpBasicAuthenticator("api",
-	                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+	                           "YOUR_API_KEY");
      RestRequest request = new RestRequest();
      request.AddParameter("domain",
-                           "samples.mailgun.org", ParameterType.UrlSegment);
+                           "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
      request.Resource = "{domain}/campaigns/my_campaign_id/clicks";
      request.AddParameter("groupby", "recipient");
      request.AddParameter("limit", 2);

--- a/source/samples/get-campaign-stats-by-daily-hour.rst
+++ b/source/samples/get-campaign-stats-by-daily-hour.rst
@@ -1,18 +1,18 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
+    curl -s --user 'api:YOUR_API_KEY' -G \
 	-d "groupby=daily_hour&limit=2" \
-	https://api.mailgun.net/v2/samples.mailgun.org/campaigns/my_campaign_id/stats
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/my_campaign_id/stats
 
 .. code-block:: java
 
  public static ClientResponse GetCampaignStats() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/campaigns/my_campaign_id/stats");
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/my_campaign_id/stats");
  	MultivaluedMapImpl queryParams = new MultivaluedMapImpl();
  	queryParams.add("groupby", "daily_hour");
  	queryParams.add("limit", 2);
@@ -26,8 +26,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $campaignId = 'myexamplecampaign';
 
   # Issue the call to the client.
@@ -40,15 +40,15 @@
 
  def get_campaign_stats():
      return requests.get(
-         ("https://api.mailgun.net/v2/samples.mailgun.org/campaigns"
+         ("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns"
           "/my_campaign_id/stats?groupby=daily_hour&limit=2"),
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'))
+         auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
  def get_campaign_stats
-   RestClient.get("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-                  "@api.mailgun.net/v2/samples.mailgun.org/campaigns/"\
+   RestClient.get("https://api:YOUR_API_KEY"\
+                  "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/"\
                   "my_campaign_id/stats?groupby=daily_hour&limit=2")
  end
 
@@ -59,11 +59,11 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "{domain}/campaigns/my_campaign_id/stats";
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("groupby", "daily_hour");
  	request.AddParameter("limit", 2);
  	return client.Execute(request);

--- a/source/samples/get-campaign-stats.rst
+++ b/source/samples/get-campaign-stats.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/samples.mailgun.org/campaigns/my_campaign_id/stats
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/my_campaign_id/stats
 
 .. code-block:: java
 
  public static ClientResponse GetCampaignStats() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/campaigns/my_campaign_id/stats");
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/my_campaign_id/stats");
  	return webResource.get(ClientResponse.class);
  }
 
@@ -22,8 +22,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $campaignId = 'myexamplecampaign';
 
   # Issue the call to the client.
@@ -33,14 +33,14 @@
 
  def get_campaign_stats():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/campaigns/my_campaign_id/stats",
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/my_campaign_id/stats",
+         auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
  def get_campaign_stats
-   RestClient.get("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-                  "@api.mailgun.net/v2/samples.mailgun.org/campaigns/"\
+   RestClient.get("https://api:YOUR_API_KEY"\
+                  "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns/"\
                   "my_campaign_id/stats")
  end
 
@@ -51,11 +51,11 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "{domain}/campaigns/my_campaign_id/stats";
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	return client.Execute(request);
  }
 

--- a/source/samples/get-campaigns.rst
+++ b/source/samples/get-campaigns.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/samples.mailgun.org/campaigns
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns
 
 .. code-block:: java
 
  public static ClientResponse GetCampaigns() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/campaigns");
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns");
  	MultivaluedMapImpl queryParams = new MultivaluedMapImpl();
  	queryParams.add("limit", 2);
  	return webResource.queryParams(queryParams).get(ClientResponse.class);
@@ -24,8 +24,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("$domain/campaigns", array('limit' => 5, 'skip' => 5));
@@ -34,14 +34,14 @@
 
  def get_campaigns():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/campaigns",
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns",
+         auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
  def get_campaigns
-   RestClient.get("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-                  "@api.mailgun.net/v2/samples.mailgun.org/campaigns")
+   RestClient.get("https://api:YOUR_API_KEY"\
+                  "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/campaigns")
  end
 
 .. code-block:: csharp
@@ -51,10 +51,10 @@
      client.BaseUrl = "https://api.mailgun.net/v2";
      client.Authenticator =
 	new HttpBasicAuthenticator("api",
-	                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+	                           "YOUR_API_KEY");
      RestRequest request = new RestRequest();
      request.AddParameter("domain",
-                           "samples.mailgun.org", ParameterType.UrlSegment);
+                           "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
      request.Resource = "{domain}/campaigns";
      request.AddParameter("limit", 2);
      return client.Execute(request);

--- a/source/samples/get-complaint.rst
+++ b/source/samples/get-complaint.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/samples.mailgun.org/complaints/baz@example.com
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/complaints/baz@example.com
 
 .. code-block:: java
 
  public static ClientResponse GetComplaint() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/" +
  				"complaints/baz@example.com");
  	return webResource.get(ClientResponse.class);
  }
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
   $complaint = 'user@example.com';
 
   # Issue the call to the client.
@@ -34,14 +34,14 @@
 
  def get_complaint():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/complaints/baz@example.com",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/complaints/baz@example.com",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def get_complaint
-   RestClient.get("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-                  "@api.mailgun.net/v2/samples.mailgun.org/complaints/"\
+   RestClient.get("https://api:YOUR_API_KEY"\
+                  "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/complaints/"\
                   "baz@example.com"){|response, request, result| response }
  end
 
@@ -52,10 +52,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/complaints/baz@example.com";
  	return client.Execute(request);
  }

--- a/source/samples/get-complaints.rst
+++ b/source/samples/get-complaints.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/samples.mailgun.org/complaints
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/complaints
 
 .. code-block:: java
 
  public static ClientResponse GetComplaints() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/" +
  				"complaints");
  	return webResource.get(ClientResponse.class);
  }
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("$domain/complaints", array(
@@ -36,14 +36,14 @@
 
  def get_complaints():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/complaints",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/complaints",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def get_complaints
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/complaints"
+   RestClient.get "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/complaints"
  end
 
 .. code-block:: csharp
@@ -53,10 +53,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/complaints";
  	return client.Execute(request);
  }

--- a/source/samples/get-credentials.rst
+++ b/source/samples/get-credentials.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/domains/samples.mailgun.org/credentials
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/credentials
 
 .. code-block:: java
 
  public static ClientResponse GetCredentials() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/domains/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME" +
  				"/credentials");
  	return webResource.get(ClientResponse.class);
  }
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("domains/$domain/credentials", array(
@@ -36,14 +36,14 @@
 
  def get_credentials():
      return requests.get(
-         "https://api.mailgun.net/v2/domains/samples.mailgun.org/credentials",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/credentials",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def get_credentials
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/domains/samples.mailgun.org/credentials"
+   RestClient.get "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/credentials"
  end
 
 .. code-block:: csharp
@@ -53,10 +53,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org",
+ 	                     "YOUR_DOMAIN_NAME",
  	                     ParameterType.UrlSegment);
  	request.Resource = "domains/{domain}/credentials";
  	return client.Execute(request);

--- a/source/samples/get-domain.rst
+++ b/source/samples/get-domain.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/domains/samples.mailgun.org
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME
 
 .. code-block:: java
 
  public static ClientResponse GetDomain() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/domains/samples.mailgun.org);
+ 		client.resource("https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME);
  	return webResource.get(ClientResponse.class);
  }
 
@@ -22,8 +22,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("domains/$domain");
@@ -32,14 +32,14 @@
 
  def get_domain():
      return requests.get(
-         "https://api.mailgun.net/v2/domains/samples.mailgun.org",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def get_domain
-   RestClient.get("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-                  "@api.mailgun.net/v2/domains/samples.mailgun.org"\
+   RestClient.get("https://api:YOUR_API_KEY"\
+                  "@api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME"\
                   {|response, request, result| response }
  end
 
@@ -50,10 +50,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
-                            "samples.mailgun.org", ParameterType.UrlSegment);
+                            "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
        request.Resource = "/domains/{domain}";
  	return client.Execute(request);
  }

--- a/source/samples/get-domains.rst
+++ b/source/samples/get-domains.rst
@@ -1,7 +1,7 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
+    curl -s --user 'api:YOUR_API_KEY' -G \
 	https://api.mailgun.net/v2/domains \
 	-d skip=0 \
 	-d limit=3
@@ -11,7 +11,7 @@
  public static ClientResponse GetDomains() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/domains");
  	MultivaluedMapImpl queryParams = new MultivaluedMapImpl();
@@ -27,7 +27,7 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
+  $mgClient = new Mailgun('YOUR_API_KEY');
 
   # Issue the call to the client.
   $result = $mgClient->get("domains", array('limit' => 5, 'skip' => 10));
@@ -37,14 +37,14 @@
  def get_domains():
      return requests.get(
          "https://api.mailgun.net/v2/domains",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         auth=("api", "YOUR_API_KEY"),
          params={"skip": 0,
                  "limit": 3})
 
 .. code-block:: rb
 
  def get_domains
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
+   RestClient.get "https://api:YOUR_API_KEY"\
    "@api.mailgun.net/v2/domains", :params => {
      :skip => 0,
      :limit => 3
@@ -58,7 +58,7 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "domains";
  	request.AddParameter("skip", 0);

--- a/source/samples/get-list-members.rst
+++ b/source/samples/get-list-members.rst
@@ -2,7 +2,7 @@
 .. code-block:: bash
 
     curl -s --user 'api:YOUR_API_KEY' -G \
-	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members
+	https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members
 
 .. code-block:: java
 
@@ -12,7 +12,7 @@
  			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@YOUR_DOMAIN_NAME/members");
+ 				"LIST@YOUR_DOMAIN_NAME/members");
  	return webResource.get(ClientResponse.class);
  }
 
@@ -24,7 +24,7 @@
 
   # Instantiate the client.
   $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'dev@YOUR_DOMAIN_NAME';
+  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("lists/$listAddress/members", array(
@@ -37,14 +37,14 @@
 
  def list_members():
      return requests.get(
-         "https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members",
+         "https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members",
          auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
  def list_members
    RestClient.get("https://api:YOUR_API_KEY" \
-                  "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members")
+                  "@api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members")
  end
 
 .. code-block:: csharp
@@ -57,7 +57,7 @@
  		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}/members";
- 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "LIST@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	return client.Execute(request);
  }
 
@@ -65,5 +65,5 @@
 
  func GetMembers(domain, apiKey string) (int, []mailgun.Member, error) {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.GetMembers(-1, -1, mailgun.All, "dev@YOUR_DOMAIN_NAME")
+   return mg.GetMembers(-1, -1, mailgun.All, "LIST@YOUR_DOMAIN_NAME")
  }

--- a/source/samples/get-list-members.rst
+++ b/source/samples/get-list-members.rst
@@ -1,18 +1,18 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/lists/dev@samples.mailgun.org/members
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members
 
 .. code-block:: java
 
  public static ClientResponse ListingMembers() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@samples.mailgun.org/members");
+ 				"dev@YOUR_DOMAIN_NAME/members");
  	return webResource.get(ClientResponse.class);
  }
 
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $listAddress = 'dev@samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $listAddress = 'dev@YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("lists/$listAddress/members", array(
@@ -37,14 +37,14 @@
 
  def list_members():
      return requests.get(
-         "https://api.mailgun.net/v2/lists/dev@samples.mailgun.org/members",
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'))
+         "https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members",
+         auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
  def list_members
-   RestClient.get("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0" \
-                  "@api.mailgun.net/v2/lists/dev@samples.mailgun.org/members")
+   RestClient.get("https://api:YOUR_API_KEY" \
+                  "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members")
  end
 
 .. code-block:: csharp
@@ -54,10 +54,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}/members";
- 	request.AddParameter("list", "dev@samples.mailgun.org", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	return client.Execute(request);
  }
 
@@ -65,5 +65,5 @@
 
  func GetMembers(domain, apiKey string) (int, []mailgun.Member, error) {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.GetMembers(-1, -1, mailgun.All, "dev@samples.mailgun.org")
+   return mg.GetMembers(-1, -1, mailgun.All, "dev@YOUR_DOMAIN_NAME")
  }

--- a/source/samples/get-list-stats.rst
+++ b/source/samples/get-list-stats.rst
@@ -1,18 +1,18 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/lists/dev@samples.mailgun.org/stats
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/stats
 
 .. code-block:: java
 
  public static ClientResponse GetListStats() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@samples.mailgun.org/stats");
+ 				"dev@YOUR_DOMAIN_NAME/stats");
  	return webResource.get(ClientResponse.class);
  }
 
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $listAddress = 'dev@samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $listAddress = 'dev@YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("lists/$listAddress/stats", array(
@@ -36,14 +36,14 @@
 
  def get_list_stats():
      return requests.get(
-         "https://api.mailgun.net/v2/lists/dev@samples.mailgun.org/stats",
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'))
+         "https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/stats",
+         auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
  def get_list_stats
-   RestClient.get("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0" \
-                  "@api.mailgun.net/v2/lists/dev@samples.mailgun.org/stats")
+   RestClient.get("https://api:YOUR_API_KEY" \
+                  "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/stats")
  end
 
 .. code-block:: csharp
@@ -53,10 +53,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}/stats";
- 	request.AddParameter("list", "dev@samples.mailgun.org", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	return client.Execute(request);
  }
 

--- a/source/samples/get-list-stats.rst
+++ b/source/samples/get-list-stats.rst
@@ -2,7 +2,7 @@
 .. code-block:: bash
 
     curl -s --user 'api:YOUR_API_KEY' -G \
-	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/stats
+	https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/stats
 
 .. code-block:: java
 
@@ -12,7 +12,7 @@
  			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@YOUR_DOMAIN_NAME/stats");
+ 				"LIST@YOUR_DOMAIN_NAME/stats");
  	return webResource.get(ClientResponse.class);
  }
 
@@ -24,7 +24,7 @@
 
   # Instantiate the client.
   $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'dev@YOUR_DOMAIN_NAME';
+  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("lists/$listAddress/stats", array(
@@ -36,14 +36,14 @@
 
  def get_list_stats():
      return requests.get(
-         "https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/stats",
+         "https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/stats",
          auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
  def get_list_stats
    RestClient.get("https://api:YOUR_API_KEY" \
-                  "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/stats")
+                  "@api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/stats")
  end
 
 .. code-block:: csharp
@@ -56,7 +56,7 @@
  		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}/stats";
- 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "LIST@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	return client.Execute(request);
  }
 

--- a/source/samples/get-log-entry.rst
+++ b/source/samples/get-log-entry.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/samples.mailgun.org/log \
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/log \
 	-d skip=50 \
 	-d limit=1
 
@@ -11,9 +11,9 @@
  public static ClientResponse GetLogs() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/log");
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/log");
  	MultivaluedMapImpl queryParams = new MultivaluedMapImpl();
  	queryParams.add("skip", 50);
  	queryParams.add("limit", 1);
@@ -27,8 +27,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("$domain/log", array(
@@ -40,16 +40,16 @@
 
  def get_logs():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/log",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/log",
+         auth=("api", "YOUR_API_KEY"),
          params={"skip": 50,
                  "limit": 1})
 
 .. code-block:: rb
 
  def get_logs
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/log", :params => {
+   RestClient.get "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/log", :params => {
      :skip => 50,
      :limit => 1
    }
@@ -62,10 +62,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/log";
  	request.AddParameter("skip", 50);
  	request.AddParameter("limit", 1);

--- a/source/samples/get-mailboxes.rst
+++ b/source/samples/get-mailboxes.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/samples.mailgun.org/mailboxes
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/mailboxes
 
 .. code-block:: java
 
  public static ClientResponse GetMailboxes() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/mailboxes");
  	return webResource.get(ClientResponse.class);
  }
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("$domain/mailboxes", array(
@@ -36,14 +36,14 @@
 
  def get_mailboxes():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/mailboxes",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/mailboxes",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def get_mailboxes
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/mailboxes"
+   RestClient.get "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/mailboxes"
  end
 
 .. code-block:: csharp
@@ -53,10 +53,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org",
+ 	                     "YOUR_DOMAIN_NAME",
  	                     ParameterType.UrlSegment);
  	request.Resource = "{domain}/mailboxes";
  	return client.Execute(request);

--- a/source/samples/get-parse.rst
+++ b/source/samples/get-parse.rst
@@ -27,7 +27,7 @@
 
   # Instantiate the client.
   $mgClient = new Mailgun('pubkey-5ogiflzbnjrljiky49qxsiozqef5jxp7');
-  $domain = 'samples.mailgun.org';
+  $domain = 'YOUR_DOMAIN_NAME';
   $addressList = 'Alice <alice@example.com>,bob@example.com,example.com';
 
   # Issue the call to the client.

--- a/source/samples/get-route.rst
+++ b/source/samples/get-route.rst
@@ -1,7 +1,7 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
+    curl -s --user 'api:YOUR_API_KEY' \
 	https://api.mailgun.net/v2/routes/4f3bad2335335426750048c6
 
 .. code-block:: java
@@ -9,7 +9,7 @@
  public static ClientResponse GetRoute() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/routes" +
  				"/4e97c1b2ba8a48567f007fb6");
@@ -23,7 +23,7 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
+  $mgClient = new Mailgun('YOUR_API_KEY');
   $routeId = '4e97c1b2ba8a48567f007fb6';
 
   # Issue the call to the client.
@@ -34,13 +34,13 @@
  def get_route():
      return requests.get(
          "https://api.mailgun.net/v2/routes/4e97c1b2ba8a48567f007fb6",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def get_route
    RestClient.
-     get("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
+     get("https://api:YOUR_API_KEY"\
          "@api.mailgun.net/v2/routes/"\
          "4e97c1b2ba8a48567f007fb6"){|response, request, result| response }
  end
@@ -52,7 +52,7 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "routes/{id}";
  	request.AddUrlSegment("id", "4e97c1b2ba8a48567f007fb6");

--- a/source/samples/get-routes.rst
+++ b/source/samples/get-routes.rst
@@ -1,7 +1,7 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
+    curl -s --user 'api:YOUR_API_KEY' -G \
 	https://api.mailgun.net/v2/routes \
 	-d skip=1 \
 	-d limit=1
@@ -11,7 +11,7 @@
  public static ClientResponse GetRoutes() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/routes");
  	MultivaluedMapImpl queryParams = new MultivaluedMapImpl();
@@ -27,7 +27,7 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
+  $mgClient = new Mailgun('YOUR_API_KEY');
 
   # Issue the call to the client.
   $result = $mgClient->get("routes", array('skip' => 5, 'limit' => 10));
@@ -37,14 +37,14 @@
  def get_routes():
      return requests.get(
          "https://api.mailgun.net/v2/routes",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         auth=("api", "YOUR_API_KEY"),
          params={"skip": 1,
                  "limit": 1})
 
 .. code-block:: rb
 
  def get_routes
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
+   RestClient.get "https://api:YOUR_API_KEY"\
    "@api.mailgun.net/v2/routes", :params => {
      :skip => 1,
      :limit => 1
@@ -58,7 +58,7 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "routes";
  	request.AddParameter("skip", 1);

--- a/source/samples/get-stats.rst
+++ b/source/samples/get-stats.rst
@@ -1,7 +1,7 @@
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/samples.mailgun.org/stats \
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/stats \
 	-d event='sent' \
 	-d event='opened' \
 	-d skip=1 \
@@ -12,9 +12,9 @@
  public static ClientResponse GetStats() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/stats");
  	MultivaluedMapImpl queryParams = new MultivaluedMapImpl();
  	queryParams.add("event", "sent");
@@ -31,8 +31,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("$domain/stats", array(
@@ -43,8 +43,8 @@
 
  def get_stats():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/stats",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/stats",
+         auth=("api", "YOUR_API_KEY"),
          params={"event": ["sent", "opened"],
                  "skip": 1,
                  "limit": 2})
@@ -59,8 +59,8 @@
    url_params[:event] = "opened"
    query_string = url_params.collect {|k, v| "#{k.to_s}=#{CGI::escape(v.to_s)}"}.
      join("&")
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/stats?#{query_string}"
+   RestClient.get "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/stats?#{query_string}"
  end
 
 .. code-block:: csharp
@@ -70,10 +70,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/stats";
  	request.AddParameter("event", "sent");
  	request.AddParameter("event", "opened");

--- a/source/samples/get-unsubscribes.rst
+++ b/source/samples/get-unsubscribes.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/samples.mailgun.org/unsubscribes
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/unsubscribes
 
 .. code-block:: java
 
  public static ClientResponse GetUnsubscribes() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/unsubscribes");
  	return webResource.get(ClientResponse.class);
  }
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("$domain/unsubscribes", array(
@@ -36,14 +36,14 @@
 
  def get_unsubscribes():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/unsubscribes",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/unsubscribes",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def get_unsubscribes
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/unsubscribes"
+   RestClient.get "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/unsubscribes"
  end
 
 .. code-block:: csharp
@@ -53,10 +53,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/unsubscribes";
  	return client.Execute(request);
  }

--- a/source/samples/get-webhook.rst
+++ b/source/samples/get-webhook.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/domains/samples.mailgun.org/webhooks/click
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks/click
 
 .. code-block:: java
 
  public static ClientResponse GetDomain() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/domains/samples.mailgun.org/webhooks/click);
+ 		client.resource("https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks/click);
  	return webResource.get(ClientResponse.class);
  }
 
@@ -22,8 +22,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("$domain/webhooks/click");
@@ -33,13 +33,13 @@
  def get_domain():
      return requests.get(
          "https://api.mailgun.net/v2/domains/webhooks/click",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def get_domain
-   RestClient.get("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-                  "@api.mailgun.net/v2/domains/samples.mailgun.org/webhooks/click"\
+   RestClient.get("https://api:YOUR_API_KEY"\
+                  "@api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks/click"\
                   {|response, request, result| response }
  end
 
@@ -50,10 +50,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
-                            "samples.mailgun.org", ParameterType.UrlSegment);
+                            "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
        request.Resource = "/domains/{domain}/webhooks/click";
  	return client.Execute(request);
  }

--- a/source/samples/get-webhooks.rst
+++ b/source/samples/get-webhooks.rst
@@ -1,17 +1,17 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -G \
-	https://api.mailgun.net/v2/domains/samples.mailgun.org/webhooks
+    curl -s --user 'api:YOUR_API_KEY' -G \
+	https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks
 
 .. code-block:: java
 
  public static ClientResponse GetBounces() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/webhooks");
  	return webResource.get(ClientResponse.class);
  }
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->get("$domain/bounces/webhooks");
@@ -33,14 +33,14 @@
 
  def get_bounces():
      return requests.get(
-         "https://api.mailgun.net/v2/samples.mailgun.org/bounces/webhooks",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"))
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/bounces/webhooks",
+         auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
  def get_bounces
-   RestClient.get "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/bounces/webhooks"
+   RestClient.get "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/bounces/webhooks"
  end
 
 .. code-block:: csharp
@@ -50,10 +50,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/bounces/webhooks";
  	return client.Execute(request);
  }

--- a/source/samples/remove-list-member.rst
+++ b/source/samples/remove-list-member.rst
@@ -1,18 +1,18 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -X DELETE \
-	https://api.mailgun.net/v2/lists/dev@samples.mailgun.org/members/bar@example.com
+    curl -s --user 'api:YOUR_API_KEY' -X DELETE \
+	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members/bar@example.com
 
 .. code-block:: java
 
  public static ClientResponse RemoveMember() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@samples.mailgun.org/members/bar@example.com");
+ 				"dev@YOUR_DOMAIN_NAME/members/bar@example.com");
  	return webResource.delete(ClientResponse.class);
  }
 
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $listAddress = 'dev@samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $listAddress = 'dev@YOUR_DOMAIN_NAME';
   $listMember = 'bar@example.com';
 
   # Issue the call to the client.
@@ -34,15 +34,15 @@
 
  def remove_member():
      return requests.delete(
-         ("https://api.mailgun.net/v2/lists/dev@samples.mailgun.org/members"
+         ("https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members"
           "/bar@example.com"),
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'))
+         auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
  def remove_member
-   RestClient.delete("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0" \
-                     "@api.mailgun.net/v2/lists/dev@samples.mailgun.org/members" \
+   RestClient.delete("https://api:YOUR_API_KEY" \
+                     "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members" \
                      "/bar@example.com")
  end
 
@@ -53,10 +53,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}/members/{member}";
- 	request.AddParameter("list", "dev@samples.mailgun.org", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("member", "bar@example.com");
  	request.Method = Method.DELETE;
  	return client.Execute(request);
@@ -66,5 +66,5 @@
 
  func DeleteListMember(domain, apiKey string) error {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.DeleteMember("joe@example.com", "dev@samples.mailgun.org")
+   return mg.DeleteMember("joe@example.com", "dev@YOUR_DOMAIN_NAME")
  }

--- a/source/samples/remove-list-member.rst
+++ b/source/samples/remove-list-member.rst
@@ -2,7 +2,7 @@
 .. code-block:: bash
 
     curl -s --user 'api:YOUR_API_KEY' -X DELETE \
-	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members/bar@example.com
+	https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members/bar@example.com
 
 .. code-block:: java
 
@@ -12,7 +12,7 @@
  			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@YOUR_DOMAIN_NAME/members/bar@example.com");
+ 				"LIST@YOUR_DOMAIN_NAME/members/bar@example.com");
  	return webResource.delete(ClientResponse.class);
  }
 
@@ -24,7 +24,7 @@
 
   # Instantiate the client.
   $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'dev@YOUR_DOMAIN_NAME';
+  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
   $listMember = 'bar@example.com';
 
   # Issue the call to the client.
@@ -34,7 +34,7 @@
 
  def remove_member():
      return requests.delete(
-         ("https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members"
+         ("https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members"
           "/bar@example.com"),
          auth=('api', 'YOUR_API_KEY'))
 
@@ -42,7 +42,7 @@
 
  def remove_member
    RestClient.delete("https://api:YOUR_API_KEY" \
-                     "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members" \
+                     "@api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members" \
                      "/bar@example.com")
  end
 
@@ -56,7 +56,7 @@
  		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}/members/{member}";
- 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "LIST@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("member", "bar@example.com");
  	request.Method = Method.DELETE;
  	return client.Execute(request);
@@ -66,5 +66,5 @@
 
  func DeleteListMember(domain, apiKey string) error {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.DeleteMember("joe@example.com", "dev@YOUR_DOMAIN_NAME")
+   return mg.DeleteMember("joe@example.com", "LIST@YOUR_DOMAIN_NAME")
  }

--- a/source/samples/remove-mailing-list.rst
+++ b/source/samples/remove-mailing-list.rst
@@ -2,7 +2,7 @@
 .. code-block:: bash
 
     curl -s --user 'api:YOUR_API_KEY' -X DELETE \
-	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME
+	https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME
 
 .. code-block:: java
 
@@ -12,7 +12,7 @@
  			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@YOUR_DOMAIN_NAME");
+ 				"LIST@YOUR_DOMAIN_NAME");
  	return webResource.delete(ClientResponse.class);
  }
 
@@ -24,7 +24,7 @@
 
   # Instantiate the client.
   $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'dev@YOUR_DOMAIN_NAME';
+  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->delete("lists/$listAddress");
@@ -33,14 +33,14 @@
 
  def remove_list():
      return requests.delete(
-         "https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME",
+         "https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME",
          auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
  def remove_list
    RestClient.delete("https://api:YOUR_API_KEY" \
-                     "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME")
+                     "@api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME")
  end
 
 .. code-block:: csharp
@@ -53,7 +53,7 @@
  		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}";
- 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "LIST@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Method = Method.DELETE;
  	return client.Execute(request);
  }
@@ -62,5 +62,5 @@
 
  func DeleteList(domain, apiKey string) error {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.DeleteList("dev@YOUR_DOMAIN_NAME")
+   return mg.DeleteList("LIST@YOUR_DOMAIN_NAME")
  }

--- a/source/samples/remove-mailing-list.rst
+++ b/source/samples/remove-mailing-list.rst
@@ -1,18 +1,18 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -X DELETE \
-	https://api.mailgun.net/v2/lists/dev@samples.mailgun.org
+    curl -s --user 'api:YOUR_API_KEY' -X DELETE \
+	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME
 
 .. code-block:: java
 
  public static ClientResponse RemoveMailingList() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@samples.mailgun.org");
+ 				"dev@YOUR_DOMAIN_NAME");
  	return webResource.delete(ClientResponse.class);
  }
 
@@ -23,8 +23,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $listAddress = 'dev@samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $listAddress = 'dev@YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
   $result = $mgClient->delete("lists/$listAddress");
@@ -33,14 +33,14 @@
 
  def remove_list():
      return requests.delete(
-         "https://api.mailgun.net/v2/lists/dev@samples.mailgun.org",
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'))
+         "https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME",
+         auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
  def remove_list
-   RestClient.delete("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0" \
-                     "@api.mailgun.net/v2/lists/dev@samples.mailgun.org")
+   RestClient.delete("https://api:YOUR_API_KEY" \
+                     "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME")
  end
 
 .. code-block:: csharp
@@ -50,10 +50,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}";
- 	request.AddParameter("list", "dev@samples.mailgun.org", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Method = Method.DELETE;
  	return client.Execute(request);
  }
@@ -62,5 +62,5 @@
 
  func DeleteList(domain, apiKey string) error {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.DeleteList("dev@samples.mailgun.org")
+   return mg.DeleteList("dev@YOUR_DOMAIN_NAME")
  }

--- a/source/samples/send-campaign-message.rst
+++ b/source/samples/send-campaign-message.rst
@@ -1,9 +1,9 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/messages \
-	-F from='Excited User <me@samples.mailgun.org>' \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages \
+	-F from='Excited User <YOU@YOUR_DOMAIN_NAME>' \
 	-F to=baz@example.com \
 	-F subject='Hello' \
 	-F text='Testing some Mailgun awesomness!' \
@@ -14,12 +14,12 @@
  public static ClientResponse SendCampaignMessage() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/messages");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
- 	formData.add("from", "Excited User <me@samples.mailgun.org>");
+ 	formData.add("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	formData.add("to", "bar@example.com");
  	formData.add("to", "baz@example.com");
  	formData.add("subject", "Hello");
@@ -36,12 +36,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = "samples.mailgun.org";
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = "YOUR_DOMAIN_NAME";
 
   # Make the call to the client.
   $result = $mgClient->sendMessage($domain, array(
-      'from'       => 'Excited User <me@samples.mailgun.org>',
+      'from'       => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
       'to'         => 'Baz <baz@example.com>',
       'subject'    => 'Hello',
       'text'       => 'Testing some Mailgun awesomness!',
@@ -52,9 +52,9 @@
 
  def send_campaign_message():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/messages",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
-         data={"from": "Excited User <me@samples.mailgun.org>",
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
+         auth=("api", "YOUR_API_KEY"),
+         data={"from": "Excited User <YOU@YOUR_DOMAIN_NAME>",
                "to": ["baz@example.com"],
                "subject": "Hello",
                "text": "Testing some Mailgun awesomness!",
@@ -63,9 +63,9 @@
 .. code-block:: rb
 
  def send_campaign_message
-   RestClient.post("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0" \
-                   "@api.mailgun.net/v2/samples.mailgun.org/messages",
-                   :from => "Excited User <me@samples.mailgun.org>",
+   RestClient.post("https://api:YOUR_API_KEY" \
+                   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
+                   :from => "Excited User <YOU@YOUR_DOMAIN_NAME>",
                    :to => "baz@example.com",
                    :subject => "Hello",
                    :text => "Testing some Mailgun awesomness!",
@@ -79,12 +79,12 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/messages";
- 	request.AddParameter("from", "Excited User <me@samples.mailgun.org>");
+ 	request.AddParameter("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	request.AddParameter("to", "bar@example.com");
  	request.AddParameter("to", "baz@example.com");
  	request.AddParameter("subject", "Hello");

--- a/source/samples/send-complex-message.rst
+++ b/source/samples/send-complex-message.rst
@@ -1,9 +1,9 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/messages \
-	-F from='Excited User <me@samples.mailgun.org>' \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages \
+	-F from='Excited User <YOU@YOUR_DOMAIN_NAME>' \
 	-F to='foo@example.com' \
 	-F cc='bar@example.com' \
 	-F bcc='baz@example.com' \
@@ -18,12 +18,12 @@
  public static ClientResponse SendComplexMessage() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org/" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/" +
  				"messages");
  	FormDataMultiPart form = new FormDataMultiPart();
- 	form.field("from", "Excited User <me@samples.mailgun.org>");
+ 	form.field("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	form.field("to", "foo@example.com");
  	form.field("bcc", "bar@example.com");
  	form.field("cc", "baz@example.com");
@@ -49,12 +49,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = "samples.mailgun.org";
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = "YOUR_DOMAIN_NAME";
 
   # Make the call to the client.
   $result = $mgClient->sendMessage($domain, array(
-      'from'    => 'Excited User <me@samples.mailgun.org>',
+      'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
       'to'      => 'foo@example.com',
       'cc'      => 'baz@example.com',
       'bcc'     => 'bar@example.com',
@@ -69,11 +69,11 @@
 
  def send_complex_message():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/messages",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
+         auth=("api", "YOUR_API_KEY"),
          files=[("attachment", open("files/test.jpg")),
                 ("attachment", open("files/test.txt"))],
-         data={"from": "Excited User <me@samples.mailgun.org>",
+         data={"from": "Excited User <YOU@YOUR_DOMAIN_NAME>",
                "to": "foo@example.com",
                "cc": "baz@example.com",
                "bcc": "bar@example.com",
@@ -85,7 +85,7 @@
 
  def send_complex_message
    data = Multimap.new
-   data[:from] = "Excited User <me@samples.mailgun.org>"
+   data[:from] = "Excited User <YOU@YOUR_DOMAIN_NAME>"
    data[:to] = "foo@example.com"
    data[:cc] = "baz@example.com"
    data[:bcc] = "bar@example.com"
@@ -94,8 +94,8 @@
    data[:html] = "<html>HTML version of the body</html>"
    data[:attachment] = File.new(File.join("files", "test.jpg"))
    data[:attachment] = File.new(File.join("files", "test.txt"))
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/messages", data
+   RestClient.post "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages", data
  end
 
 .. code-block:: csharp
@@ -105,12 +105,12 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/messages";
- 	request.AddParameter("from", "Excited User <me@samples.mailgun.org>");
+ 	request.AddParameter("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	request.AddParameter("to", "foo@example.com");
  	request.AddParameter("cc", "baz@example.com");
  	request.AddParameter("bcc", "bar@example.com");
@@ -128,7 +128,7 @@
  func SendComplexMessage(domain, apiKey string) (string, error) {
    mg := mailgun.NewMailgun(domain, apiKey, "")
    m := mg.NewMessage(
-     "Excited User <me@samples.mailgun.org>",
+     "Excited User <YOU@YOUR_DOMAIN_NAME>",
      "Hello",
      "Testing some Mailgun awesomeness!",
      "foo@example.com",

--- a/source/samples/send-inline-image.rst
+++ b/source/samples/send-inline-image.rst
@@ -1,9 +1,9 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/messages \
-	-F from='Excited User <me@samples.mailgun.org>' \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages \
+	-F from='Excited User <YOU@YOUR_DOMAIN_NAME>' \
 	-F to='alice@example.com' \
 	-F subject='Hello' \
 	-F text='Testing some Mailgun awesomness!' \
@@ -15,12 +15,12 @@
  public static ClientResponse SendInlineImage() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/messages");
  	FormDataMultiPart form = new FormDataMultiPart();
- 	form.field("from", "Excited User <me@samples.mailgun.org>");
+ 	form.field("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	form.field("to", "baz@example.com");
  	form.field("subject", "Hello");
  	form.field("text", "Testing some Mailgun awesomness!");
@@ -39,12 +39,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = "samples.mailgun.org";
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = "YOUR_DOMAIN_NAME";
 
   # Make the call to the client.
   $result = $mgClient->sendMessage($domain, array(
-      'from'    => 'Excited User <me@samples.mailgun.org>',
+      'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
       'to'      => 'foo@example.com',
       'cc'      => 'baz@example.com',
       'bcc'     => 'bar@example.com',
@@ -59,10 +59,10 @@
 
  def send_inline_image():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/messages",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
+         auth=("api", "YOUR_API_KEY"),
          files=[("inline", open("files/test.jpg"))],
-         data={"from": "Excited User <me@samples.mailgun.org>",
+         data={"from": "Excited User <YOU@YOUR_DOMAIN_NAME>",
                "to": "bar@example.com",
                "subject": "Hello",
                "text": "Testing some Mailgun awesomness!",
@@ -72,14 +72,14 @@
 
  def send_inline_image
    data = Multimap.new
-   data[:from] = "Excited User <me@samples.mailgun.org>"
+   data[:from] = "Excited User <YOU@YOUR_DOMAIN_NAME>"
    data[:to] = "bar@example.com"
    data[:subject] = "Hello"
    data[:text] = "Testing some Mailgun awesomness!"
    data[:html] = '<html>Inline image here: <img src="cid:test.jpg"></html>'
    data[:inline] = File.new(File.join("files", "test.jpg"))
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/messages", data
+   RestClient.post "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages", data
  end
 
 .. code-block:: csharp
@@ -89,12 +89,12 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/messages";
- 	request.AddParameter("from", "Excited User <me@samples.mailgun.org>");
+ 	request.AddParameter("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	request.AddParameter("to", "baz@example.com");
  	request.AddParameter("subject", "Hello");
  	request.AddParameter("text", "Testing some Mailgun awesomness!");
@@ -109,7 +109,7 @@
  func SendInlineImage(domain, apiKey string) (string, error) {
    mg := mailgun.NewMailgun(domain, apiKey, "")
    m := mg.NewMessage(
-     "Excited User <me@samples.mailgun.org>",
+     "Excited User <YOU@YOUR_DOMAIN_NAME>",
      "Hello",
      "Testing some Mailgun awesomeness!",
      "foo@example.com",

--- a/source/samples/send-message-no-tracking.rst
+++ b/source/samples/send-message-no-tracking.rst
@@ -1,9 +1,9 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/messages \
-	-F from='Sender Bob <sbob@samples.mailgun.org>' \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages \
+	-F from='Sender Bob <sbob@YOUR_DOMAIN_NAME>' \
 	-F to='alice@example.com' \
 	-F subject='Hello' \
 	-F text='Testing some Mailgun awesomness!' \
@@ -14,12 +14,12 @@
  public static ClientResponse SendMessageNoTracking() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/messages");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
- 	formData.add("from", "Excited User <me@samples.mailgun.org>");
+ 	formData.add("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	formData.add("to", "bar@example.com");
  	formData.add("to", "baz@example.com");
  	formData.add("subject", "Hello");
@@ -36,12 +36,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = "samples.mailgun.org";
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = "YOUR_DOMAIN_NAME";
 
   # Make the call to the client.
   $result = $mgClient->sendMessage($domain, array(
-      'from'       => 'Excited User <me@samples.mailgun.org>',
+      'from'       => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
       'to'         => 'foo@example.com',
       'subject'    => 'Hello',
       'text'       => 'Testing some Mailgun awesomness!',
@@ -52,9 +52,9 @@
 
  def send_message_no_tracking():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/messages",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
-         data={"from": "Excited User <me@samples.mailgun.org>",
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
+         auth=("api", "YOUR_API_KEY"),
+         data={"from": "Excited User <YOU@YOUR_DOMAIN_NAME>",
                "to": ["bar@example.com", "baz@example.com"],
                "subject": "Hello",
                "text": "Testing some Mailgun awesomness!",
@@ -63,9 +63,9 @@
 .. code-block:: rb
 
  def send_message_no_tracking
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/messages",
-   :from => "Excited User <me@samples.mailgun.org>",
+   RestClient.post "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
+   :from => "Excited User <YOU@YOUR_DOMAIN_NAME>",
    :to => "bar@example.com, baz@example.com",
    :subject => "Hello",
    :text => "Testing some Mailgun awesomness!",
@@ -79,12 +79,12 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/messages";
- 	request.AddParameter("from", "Excited User <me@samples.mailgun.org>");
+ 	request.AddParameter("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	request.AddParameter("to", "bar@example.com");
  	request.AddParameter("to", "baz@example.com");
  	request.AddParameter("subject", "Hello");
@@ -99,7 +99,7 @@
  func SendMessageNoTracking(domain, apiKey string) (string, error) {
    mg := mailgun.NewMailgun(domain, apiKey, "")
    m := mg.NewMessage(
-     "Excited User <me@samples.mailgun.org>",
+     "Excited User <YOU@YOUR_DOMAIN_NAME>",
      "Hello",
      "Testing some Mailgun awesomeness!",
      "foo@example.com",

--- a/source/samples/send-mime-message.rst
+++ b/source/samples/send-mime-message.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/messages.mime \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages.mime \
 	-F to='bob@example.com' \
 	-F message=@files/message.mime
 
@@ -11,9 +11,9 @@
  public static ClientResponse SendMimeMessage() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/messages.mime");
  	FormDataMultiPart form = new FormDataMultiPart();
  	form.field("to", "bar@example.com");
@@ -33,13 +33,13 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = "samples.mailgun.org";
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = "YOUR_DOMAIN_NAME";
 
   # Make the call to the client.
   $result = $mgClient->sendMessage(
       $domain, array(
-          'from' => 'Excited User <me@samples.mailgun.org>',
+          'from' => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
           'to'   => 'foo@example.com'
       ),
       '<Pass fully formed MIME string here>'
@@ -49,16 +49,16 @@
 
  def send_mime_message():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/messages.mime",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages.mime",
+         auth=("api", "YOUR_API_KEY"),
          data={"to": "bar@example.com"},
          files={"message": open("files/message.mime")})
 
 .. code-block:: rb
 
  def send_mime_message
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/messages.mime",
+   RestClient.post "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages.mime",
    :to => "bar@example.com",
    :message => File.new(File.join("files", "message.mime"))
  end
@@ -70,10 +70,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/messages.mime";
  	request.AddParameter("to", "bar@example.com");
  	request.AddFile("message", Path.Combine("files", "message.mime"));

--- a/source/samples/send-scheduled-message.rst
+++ b/source/samples/send-scheduled-message.rst
@@ -1,9 +1,9 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/messages \
-	-F from='Sender Bob <sbob@samples.mailgun.org>' \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages \
+	-F from='Sender Bob <sbob@YOUR_DOMAIN_NAME>' \
 	-F to='alice@example.com' \
 	-F subject='Hello' \
 	-F text='Testing some Mailgun awesomness!' \
@@ -14,12 +14,12 @@
  public static ClientResponse SendScheduledMessage() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/messages");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
- 	formData.add("from", "Excited User <me@samples.mailgun.org>");
+ 	formData.add("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	formData.add("to", "bar@example.com");
  	formData.add("subject", "Hello");
  	formData.add("text", "Testing some Mailgun awesomness!");
@@ -35,12 +35,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = "samples.mailgun.org";
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = "YOUR_DOMAIN_NAME";
 
   # Make the call to the client.
   $result = $mgClient->sendMessage($domain, array(
-      'from'           => 'Excited User <me@samples.mailgun.org>',
+      'from'           => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
       'to'             => 'Baz <baz@example.com>',
       'subject'        => 'Hello',
       'text'           => 'Testing some Mailgun awesomness!',
@@ -51,9 +51,9 @@
 
  def send_scheduled_message():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/messages",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
-         data={"from": "Excited User <me@samples.mailgun.org>",
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
+         auth=("api", "YOUR_API_KEY"),
+         data={"from": "Excited User <YOU@YOUR_DOMAIN_NAME>",
                "to": "bar@example.com",
                "subject": "Hello",
                "text": "Testing some Mailgun awesomness!",
@@ -62,9 +62,9 @@
 .. code-block:: rb
 
  def send_scheduled_message
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/messages",
-   :from => "Excited User <me@samples.mailgun.org>",
+   RestClient.post "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
+   :from => "Excited User <YOU@YOUR_DOMAIN_NAME>",
    :to => "bar@example.com",
    :subject => "Hello",
    :text => "Testing some Mailgun awesomeness!",
@@ -78,12 +78,12 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/messages";
- 	request.AddParameter("from", "Excited User <me@samples.mailgun.org>");
+ 	request.AddParameter("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	request.AddParameter("to", "bar@example.com");
  	request.AddParameter("subject", "Hello");
  	request.AddParameter("text", "Testing some Mailgun awesomness!");
@@ -97,7 +97,7 @@
  func SendScheduledMessage(domain, apiKey string) (string, error) {
    mg := mailgun.NewMailgun(domain, apiKey, publicApiKey)
    m := mg.NewMessage(
-     "Excited User <me@samples.mailgun.org>", 
+     "Excited User <YOU@YOUR_DOMAIN_NAME>", 
      "Hello", 
      "Testing some Mailgun awesomeness!", 
      "bar@example.com",

--- a/source/samples/send-simple-message.rst
+++ b/source/samples/send-simple-message.rst
@@ -1,8 +1,8 @@
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/messages \
-	-F from='Excited User <me@samples.mailgun.org>' \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages \
+	-F from='Excited User <YOU@YOUR_DOMAIN_NAME>' \
 	-F to=baz@example.com \
 	-F to=bar@example.com \
 	-F subject='Hello' \
@@ -13,12 +13,12 @@
  public static ClientResponse SendSimpleMessage() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/messages");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
- 	formData.add("from", "Excited User <me@samples.mailgun.org>");
+ 	formData.add("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	formData.add("to", "bar@example.com");
  	formData.add("to", "baz@example.com");
  	formData.add("subject", "Hello");
@@ -34,12 +34,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = "samples.mailgun.org";
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = "YOUR_DOMAIN_NAME";
 
   # Make the call to the client.
   $result = $mgClient->sendMessage($domain, array(
-      'from'    => 'Excited User <me@samples.mailgun.org>',
+      'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
       'to'      => 'Baz <baz@example.com>',
       'subject' => 'Hello',
       'text'    => 'Testing some Mailgun awesomness!'
@@ -49,9 +49,9 @@
 
  def send_simple_message():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/messages",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
-         data={"from": "Excited User <me@samples.mailgun.org>",
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
+         auth=("api", "YOUR_API_KEY"),
+         data={"from": "Excited User <YOU@YOUR_DOMAIN_NAME>",
                "to": ["bar@example.com", "baz@example.com"],
                "subject": "Hello",
                "text": "Testing some Mailgun awesomness!"})
@@ -59,9 +59,9 @@
 .. code-block:: rb
 
  def send_simple_message
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/messages",
-   :from => "Excited User <me@samples.mailgun.org>",
+   RestClient.post "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
+   :from => "Excited User <YOU@YOUR_DOMAIN_NAME>",
    :to => "bar@example.com, baz@example.com",
    :subject => "Hello",
    :text => "Testing some Mailgun awesomness!"
@@ -74,12 +74,12 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/messages";
- 	request.AddParameter("from", "Excited User <me@samples.mailgun.org>");
+ 	request.AddParameter("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	request.AddParameter("to", "bar@example.com");
  	request.AddParameter("to", "baz@example.com");
  	request.AddParameter("subject", "Hello");
@@ -93,7 +93,7 @@
  func SendSimpleMessage(domain, apiKey string) (string, error) {
    mg := mailgun.NewMailgun(domain, apiKey, publicApiKey)
    m := mg.NewMessage(
-     "Excited User <me@samples.mailgun.org>", 
+     "Excited User <YOU@YOUR_DOMAIN_NAME>", 
      "Hello", 
      "Testing some Mailgun awesomeness!", 
      "bar@example.com",

--- a/source/samples/send-tagged-message.rst
+++ b/source/samples/send-tagged-message.rst
@@ -1,9 +1,9 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-	https://api.mailgun.net/v2/samples.mailgun.org/messages \
-	-F from='Sender Bob <sbob@samples.mailgun.org>' \
+    curl -s --user 'api:YOUR_API_KEY' \
+	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages \
+	-F from='Sender Bob <sbob@YOUR_DOMAIN_NAME>' \
 	-F to='alice@example.com' \
 	-F subject='Hello' \
 	-F text='Testing some Mailgun awesomness!' \
@@ -15,12 +15,12 @@
  public static ClientResponse SendTaggedMessage() {
  	Client client = new Client();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/messages");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
- 	formData.add("from", "Excited User <me@samples.mailgun.org>");
+ 	formData.add("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	formData.add("to", "bar@example.com");
  	formData.add("subject", "Hello");
  	formData.add("text", "Testing some Mailgun awesomness!");
@@ -37,12 +37,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = "samples.mailgun.org";
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = "YOUR_DOMAIN_NAME";
 
   # Make the call to the client.
   $result = $mgClient->sendMessage($domain, array(
-      'from'    => 'Excited User <me@samples.mailgun.org>',
+      'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
       'to'      => 'Baz <baz@example.com>',
       'subject' => 'Hello',
       'text'    => 'Testing some Mailgun awesomness!',
@@ -53,9 +53,9 @@
 
  def send_tagged_message():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/messages",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
-         data={"from": "Excited User <me@samples.mailgun.org>",
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
+         auth=("api", "YOUR_API_KEY"),
+         data={"from": "Excited User <YOU@YOUR_DOMAIN_NAME>",
                "to": "bar@example.com",
                "subject": "Hello",
                "text": "Testing some Mailgun awesomness!",
@@ -65,14 +65,14 @@
 
  def send_tagged_message
    data = Multimap.new
-   data[:from] = "Excited User <me@samples.mailgun.org>"
+   data[:from] = "Excited User <YOU@YOUR_DOMAIN_NAME>"
    data[:to] = "bar@example.com"
    data[:subject] = "Hello"
    data[:text] = "Testing some Mailgun awesomness!"
    data["o:tag"] = "September newsletter"
    data["o:tag"] = "newsletters"
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/messages", data
+   RestClient.post "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages", data
  end
 
 .. code-block:: csharp
@@ -82,12 +82,12 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/messages";
- 	request.AddParameter("from", "Excited User <me@samples.mailgun.org>");
+ 	request.AddParameter("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	request.AddParameter("to", "bar@example.com");
  	request.AddParameter("subject", "Hello");
  	request.AddParameter("text", "Testing some Mailgun awesomness!");
@@ -102,7 +102,7 @@
  func SendTaggedMessage(domain, apiKey string) (string, error) {
    mg := mailgun.NewMailgun(domain, apiKey, "")
    m := mg.NewMessage(
-     "Excited User <me@samples.mailgun.org>", 
+     "Excited User <YOU@YOUR_DOMAIN_NAME>", 
      "Hello", 
      "Testing some Mailgun awesomeness!", 
      "bar@example.com",

--- a/source/samples/send-template-message.rst
+++ b/source/samples/send-template-message.rst
@@ -1,9 +1,9 @@
 
 .. code-block:: bash
 
- curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' \
-     https://api.mailgun.net/v2/samples.mailgun.org/messages \
-     -F from='Excited User <me@samples.mailgun.org>' \
+ curl -s --user 'api:YOUR_API_KEY' \
+     https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages \
+     -F from='Excited User <YOU@YOUR_DOMAIN_NAME>' \
      -F to=alice@example.com \
      -F to=bob@example.com \
      -F recipient-variables='{"bob@example.com": {"first":"Bob", "id":1}, "alice@example.com": {"first":"Alice", "id": 2}}' \
@@ -15,12 +15,12 @@
  public static ClientResponse SendTemplateMessage() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
- 		client.resource("https://api.mailgun.net/v2/samples.mailgun.org" +
+ 		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/messages");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
- 	formData.add("from", "Excited User <me@samples.mailgun.org>");
+ 	formData.add("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	formData.add("to", "alice@example.com");
  	formData.add("to", "bob@example.com");
  	formData.add("subject", "Hey, %recipient.first%");
@@ -37,12 +37,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $domain = "samples.mailgun.org";
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $domain = "YOUR_DOMAIN_NAME";
 
   # Make the call to the client.
   $result = $mgClient->sendMessage($domain, array(
-      'from'    => 'Excited User <me@samples.mailgun.org>',
+      'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
       'to'      => 'bob@example.com, alice@example.com',
       'subject' => 'Hello',
       'text'    => 'If you wish to unsubscribe,
@@ -55,9 +55,9 @@
 
  def send_template_message():
      return requests.post(
-         "https://api.mailgun.net/v2/samples.mailgun.org/messages",
-         auth=("api", "key-3ax6xnjp29jd6fds4gc373sgvjxteol0"),
-         data={"from": "Excited User <me@samples.mailgun.org>",
+         "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
+         auth=("api", "YOUR_API_KEY"),
+         data={"from": "Excited User <YOU@YOUR_DOMAIN_NAME>",
                "to": ["alice@example.com, bob@example.com"],
                "subject": "Hey, %recipient.first%",
                "text": "If you wish to unsubscribe, click http://mailgun/unsubscribe/%recipient.id%'",
@@ -67,9 +67,9 @@
 .. code-block:: rb
 
  def send_template_message
-   RestClient.post "https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0"\
-   "@api.mailgun.net/v2/samples.mailgun.org/messages",
-   :from => "Excited User <me@samples.mailgun.org>",
+   RestClient.post "https://api:YOUR_API_KEY"\
+   "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
+   :from => "Excited User <YOU@YOUR_DOMAIN_NAME>",
    :to => "alice@example.com, bob@example.com",
    :subject => "Hey, %recipient.first%",
    :text => "If you wish to unsubscribe, click http://mailgun/unsubscribe/%recipient.id%'",
@@ -83,12 +83,12 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.AddParameter("domain",
- 	                     "samples.mailgun.org", ParameterType.UrlSegment);
+ 	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/messages";
- 	request.AddParameter("from", "Excited User <me@samples.mailgun.org>");
+ 	request.AddParameter("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
  	request.AddParameter("to", "alice@example.com");
  	request.AddParameter("to", "bob@example.com");
  	request.AddParameter("subject", "Hey, %recipient.first%");
@@ -111,7 +111,7 @@
  func SendTemplateMessage(domain, apiKey string) (string, error) {
    mg := mailgun.NewMailgun(domain, apiKey, "")
    m := mg.NewMessage(
-     "Excited User <me@samples.mailgun.org>",
+     "Excited User <YOU@YOUR_DOMAIN_NAME>",
      "Hey %recipient.first%",
      "If you wish to unsubscribe, click http://mailgun/unsubscribe/%recipient.id%",
    ) // IMPORTANT: No To:-field recipients!

--- a/source/samples/smtp-send-simple-message.rst
+++ b/source/samples/smtp-send-simple-message.rst
@@ -9,7 +9,7 @@
     # now send!
     ./swaks --auth \
             --server smtp.mailgun.org \
-            --au postmaster@samples.mailgun.org \
+            --au postmaster@YOUR_DOMAIN_NAME \
             --ap 3kh9umujora5 \
             --to bar@example.com \
             --h-Subject: "Hello" \
@@ -36,7 +36,7 @@
           props.put("mail.smtps.auth","true");
           Session session = Session.getInstance(props, null);
           Message msg = new MimeMessage(session);
-          msg.setFrom(new InternetAddress("me@samples.mailgun.org"));
+          msg.setFrom(new InternetAddress("YOU@YOUR_DOMAIN_NAME"));
           msg.setRecipients(Message.RecipientType.TO,
           InternetAddress.parse("bar@example.com", false));
           msg.setSubject("Hello");
@@ -44,7 +44,7 @@
           msg.setSentDate(new Date());
           SMTPTransport t =
               (SMTPTransport)session.getTransport("smtps");
-          t.connect("smtp.mailgun.com", "postmaster@samples.mailgun.org", "3kh9umujora5");
+          t.connect("smtp.mailgun.com", "postmaster@YOUR_DOMAIN_NAME", "3kh9umujora5");
           t.sendMessage(msg, msg.getAllRecipients());
           System.out.println("Response: " + t.getLastServerResponse());
           t.close();
@@ -62,11 +62,11 @@
   $mail->isSMTP();                                      // Set mailer to use SMTP
   $mail->Host = 'smtp.mailgun.org';                     // Specify main and backup SMTP servers
   $mail->SMTPAuth = true;                               // Enable SMTP authentication
-  $mail->Username = 'postmaster@samples.mailgun.org';   // SMTP username
+  $mail->Username = 'postmaster@YOUR_DOMAIN_NAME';   // SMTP username
   $mail->Password = 'secret';                           // SMTP password
   $mail->SMTPSecure = 'tls';                            // Enable encryption, only 'tls' is accepted
 
-  $mail->From = 'me@samples.mailgun.org';
+  $mail->From = 'YOU@YOUR_DOMAIN_NAME';
   $mail->FromName = 'Mailer';
   $mail->addAddress('bar@example.com');                 // Add a recipient
 
@@ -90,12 +90,12 @@
 
   msg = MIMEText('Testing some Mailgun awesomness')
   msg['Subject'] = "Hello"
-  msg['From']    = "foo@samples.mailgun.org"
+  msg['From']    = "foo@YOUR_DOMAIN_NAME"
   msg['To']      = "bar@example.com"
 
   s = smtplib.SMTP('smtp.mailgun.org', 587)
 
-  s.login('postmaster@samples.mailgun.org', '3kh9umujora5')
+  s.login('postmaster@YOUR_DOMAIN_NAME', '3kh9umujora5')
   s.sendmail(msg['From'], msg['To'], msg.as_string())
   s.quit()
 
@@ -116,7 +116,7 @@
 
   mail = Mail.deliver do
     to      'bar@example.com'
-    from    'foo@samples.mailgun.org'
+    from    'foo@YOUR_DOMAIN_NAME'
     subject 'Hello'
 
     text_part do
@@ -128,7 +128,7 @@
 
   public static IRestResponse SendSimpleMessage() {
     // Compose a message
-    MailMessage mail = new MailMessage("foo@samples.mailgun.org", "bar@example.com");
+    MailMessage mail = new MailMessage("foo@YOUR_DOMAIN_NAME", "bar@example.com");
     mail.Subject = "Hello";
     mail.Body = "Testing some Mailgun awesomness";
 
@@ -137,7 +137,7 @@
     client.Port = 587;
     client.DeliveryMethod = SmtpDeliveryMethod.Network;
     client.UseDefaultCredentials = false;
-    client.Credentials = new System.Net.NetworkCredential("postmaster@samples.mailgun.org", "3kh9umujora5");
+    client.Credentials = new System.Net.NetworkCredential("postmaster@YOUR_DOMAIN_NAME", "3kh9umujora5");
     client.Host = "smtp.mailgun.org";
 
     client.Send(mail);

--- a/source/samples/update-list-member.rst
+++ b/source/samples/update-list-member.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -X PUT \
-	https://api.mailgun.net/v2/lists/dev@samples.mailgun.org/members/bar@example.com \
+    curl -s --user 'api:YOUR_API_KEY' -X PUT \
+	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members/bar@example.com \
 	-F subscribed=False \
 	-F name='Foo Bar'
 
@@ -11,10 +11,10 @@
  public static ClientResponse UpdateMember() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@samples.mailgun.org/members/bar@example.com");
+ 				"dev@YOUR_DOMAIN_NAME/members/bar@example.com");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("subscribed", false);
  	formData.add("name", "Foo Bar");
@@ -30,8 +30,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $listAddress = 'dev@samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $listAddress = 'dev@YOUR_DOMAIN_NAME';
   $memberAddress = 'bob@example.com';
 
   # Issue the call to the client.
@@ -44,17 +44,17 @@
 
  def update_member():
      return requests.put(
-         ("https://api.mailgun.net/v2/lists/dev@samples.mailgun.org/members"
+         ("https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members"
           "/bar@example.com"),
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'),
+         auth=('api', 'YOUR_API_KEY'),
          data={'subscribed': False,
                'name': 'Foo Bar'})
 
 .. code-block:: rb
 
  def update_member
-   RestClient.put("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0" \
-                  "@api.mailgun.net/v2/lists/dev@samples.mailgun.org/members" \
+   RestClient.put("https://api:YOUR_API_KEY" \
+                  "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members" \
                   "/bar@example.com",
                   :subscribed => false,
                   :name => 'Foo Bar')
@@ -67,10 +67,10 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}/members/{member}";
- 	request.AddParameter("list", "dev@samples.mailgun.org", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("member", "bar@example.com", ParameterType.UrlSegment);
  	request.AddParameter("subscribed", false);
  	request.AddParameter("name", "Foo Bar");
@@ -82,7 +82,7 @@
 
  func UpdateMember(domain, apiKey string) error {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   _, err = mg.UpdateMember("bar@example.com", "dev@samples.mailgun.org", mailgun.Member{
+   _, err = mg.UpdateMember("bar@example.com", "dev@YOUR_DOMAIN_NAME", mailgun.Member{
      Name: "Foo Bar",
      Subscribed: mailgun.Unsubscribed,
    })

--- a/source/samples/update-list-member.rst
+++ b/source/samples/update-list-member.rst
@@ -2,7 +2,7 @@
 .. code-block:: bash
 
     curl -s --user 'api:YOUR_API_KEY' -X PUT \
-	https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members/bar@example.com \
+	https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members/bar@example.com \
 	-F subscribed=False \
 	-F name='Foo Bar'
 
@@ -14,7 +14,7 @@
  			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@YOUR_DOMAIN_NAME/members/bar@example.com");
+ 				"LIST@YOUR_DOMAIN_NAME/members/bar@example.com");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("subscribed", false);
  	formData.add("name", "Foo Bar");
@@ -31,7 +31,7 @@
 
   # Instantiate the client.
   $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'dev@YOUR_DOMAIN_NAME';
+  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
   $memberAddress = 'bob@example.com';
 
   # Issue the call to the client.
@@ -44,7 +44,7 @@
 
  def update_member():
      return requests.put(
-         ("https://api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members"
+         ("https://api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members"
           "/bar@example.com"),
          auth=('api', 'YOUR_API_KEY'),
          data={'subscribed': False,
@@ -54,7 +54,7 @@
 
  def update_member
    RestClient.put("https://api:YOUR_API_KEY" \
-                  "@api.mailgun.net/v2/lists/dev@YOUR_DOMAIN_NAME/members" \
+                  "@api.mailgun.net/v2/lists/LIST@YOUR_DOMAIN_NAME/members" \
                   "/bar@example.com",
                   :subscribed => false,
                   :name => 'Foo Bar')
@@ -70,7 +70,7 @@
  		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
  	request.Resource = "lists/{list}/members/{member}";
- 	request.AddParameter("list", "dev@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
+ 	request.AddParameter("list", "LIST@YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.AddParameter("member", "bar@example.com", ParameterType.UrlSegment);
  	request.AddParameter("subscribed", false);
  	request.AddParameter("name", "Foo Bar");
@@ -82,7 +82,7 @@
 
  func UpdateMember(domain, apiKey string) error {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   _, err = mg.UpdateMember("bar@example.com", "dev@YOUR_DOMAIN_NAME", mailgun.Member{
+   _, err = mg.UpdateMember("bar@example.com", "LIST@YOUR_DOMAIN_NAME", mailgun.Member{
      Name: "Foo Bar",
      Subscribed: mailgun.Unsubscribed,
    })

--- a/source/samples/update-webhook.rst
+++ b/source/samples/update-webhook.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
-    curl -s --user 'api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0' -X PUT \
-	https://api.mailgun.net/v2/domains/samples.mailgun.org/webhooks/click \
+    curl -s --user 'api:YOUR_API_KEY' -X PUT \
+	https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks/click \
 	-F url='http://google.com'
 
 .. code-block:: java
@@ -10,10 +10,10 @@
  public static ClientResponse UpdateMember() {
  	Client client = Client.create();
  	client.addFilter(new HTTPBasicAuthFilter("api",
- 			"key-3ax6xnjp29jd6fds4gc373sgvjxteol0"));
+ 			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@samples.mailgun.org/members/bar@example.com");
+ 				"dev@YOUR_DOMAIN_NAME/members/bar@example.com");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("url", "http://google.com");
  	return webResource.type(MediaType.APPLICATION_FORM_URLENCODED).
@@ -28,8 +28,8 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('key-3ax6xnjp29jd6fds4gc373sgvjxteol0');
-  $listAddress = 'samples.mailgun.org';
+  $mgClient = new Mailgun('YOUR_API_KEY');
+  $listAddress = 'YOUR_DOMAIN_NAME';
   $memberAddress = 'bob@example.com';
 
   # Issue the call to the client.
@@ -41,15 +41,15 @@
 
  def update_member():
      return requests.put(
-         ("https://api.mailgun.net/v2/domains/samples.mailgun.org/webhooks/click"),
-         auth=('api', 'key-3ax6xnjp29jd6fds4gc373sgvjxteol0'),
+         ("https://api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks/click"),
+         auth=('api', 'YOUR_API_KEY'),
          data={'url': 'http://google.com'})
 
 .. code-block:: rb
 
  def update_member
-   RestClient.put("https://api:key-3ax6xnjp29jd6fds4gc373sgvjxteol0" \
-                  "@api.mailgun.net/v2/domains/samples.mailgun.org/webhooks/click" \
+   RestClient.put("https://api:YOUR_API_KEY" \
+                  "@api.mailgun.net/v2/domains/YOUR_DOMAIN_NAME/webhooks/click" \
                   "/bar@example.com",
                   :url => 'http://google.com')
  end
@@ -61,9 +61,9 @@
  	client.BaseUrl = "https://api.mailgun.net/v2";
  	client.Authenticator =
  		new HttpBasicAuthenticator("api",
- 		                           "key-3ax6xnjp29jd6fds4gc373sgvjxteol0");
+ 		                           "YOUR_API_KEY");
  	RestRequest request = new RestRequest();
- 	request.Resource = "/domains/samples.mailgun.org/webhooks/click";
+ 	request.Resource = "/domains/YOUR_DOMAIN_NAME/webhooks/click";
  	request.AddParameter("url", "http://google.com");
  	request.Method = Method.PUT;
  	return client.Execute(request);

--- a/source/samples/update-webhook.rst
+++ b/source/samples/update-webhook.rst
@@ -13,7 +13,7 @@
  			"YOUR_API_KEY"));
  	WebResource webResource =
  		client.resource("https://api.mailgun.net/v2/lists/" +
- 				"dev@YOUR_DOMAIN_NAME/members/bar@example.com");
+ 				"LIST@YOUR_DOMAIN_NAME/members/bar@example.com");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
  	formData.add("url", "http://google.com");
  	return webResource.type(MediaType.APPLICATION_FORM_URLENCODED).


### PR DESCRIPTION
To make it more obvious to users that they have to enter their own key and domain:

* Switched the sample API key to YOUR_API_KEY
* Switched the sample domain to YOUR_DOMAIN_NAME
* Switched the sample email to YOU@YOUR_DOMAIN_NAME
* Switched the sample list to LIST@YOUR_DOMAIN_NAME

Does this make sense? What did I miss?

cc @klizhentas 