### PR TITLE
Simple sending now sends to user's email

### DIFF
--- a/source/samples/send-simple-message.rst
+++ b/source/samples/send-simple-message.rst
@@ -2,8 +2,8 @@
 
     curl -s --user 'api:YOUR_API_KEY' \
 	https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages \
-	-F from='Excited User <YOU@YOUR_DOMAIN_NAME>' \
-	-F to=baz@example.com \
+	-F from='Excited User <mailgun@YOUR_DOMAIN_NAME>' \
+	-F to=YOU@YOUR_DOMAIN_NAME \
 	-F to=bar@example.com \
 	-F subject='Hello' \
 	-F text='Testing some Mailgun awesomness!'
@@ -18,9 +18,9 @@
  		client.resource("https://api.mailgun.net/v2/YOUR_DOMAIN_NAME" +
  				"/messages");
  	MultivaluedMapImpl formData = new MultivaluedMapImpl();
- 	formData.add("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
+ 	formData.add("from", "Excited User <mailgun@YOUR_DOMAIN_NAME>");
  	formData.add("to", "bar@example.com");
- 	formData.add("to", "baz@example.com");
+ 	formData.add("to", "YOU@YOUR_DOMAIN_NAME");
  	formData.add("subject", "Hello");
  	formData.add("text", "Testing some Mailgun awesomness!");
  	return webResource.type(MediaType.APPLICATION_FORM_URLENCODED).
@@ -39,8 +39,8 @@
 
   # Make the call to the client.
   $result = $mgClient->sendMessage($domain, array(
-      'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
-      'to'      => 'Baz <baz@example.com>',
+      'from'    => 'Excited User <mailgun@YOUR_DOMAIN_NAME>',
+      'to'      => 'Baz <YOU@YOUR_DOMAIN_NAME>',
       'subject' => 'Hello',
       'text'    => 'Testing some Mailgun awesomness!'
   ));
@@ -51,8 +51,8 @@
      return requests.post(
          "https://api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
          auth=("api", "YOUR_API_KEY"),
-         data={"from": "Excited User <YOU@YOUR_DOMAIN_NAME>",
-               "to": ["bar@example.com", "baz@example.com"],
+         data={"from": "Excited User <mailgun@YOUR_DOMAIN_NAME>",
+               "to": ["bar@example.com", "YOU@YOUR_DOMAIN_NAME"],
                "subject": "Hello",
                "text": "Testing some Mailgun awesomness!"})
 
@@ -61,8 +61,8 @@
  def send_simple_message
    RestClient.post "https://api:YOUR_API_KEY"\
    "@api.mailgun.net/v2/YOUR_DOMAIN_NAME/messages",
-   :from => "Excited User <YOU@YOUR_DOMAIN_NAME>",
-   :to => "bar@example.com, baz@example.com",
+   :from => "Excited User <mailgun@YOUR_DOMAIN_NAME>",
+   :to => "bar@example.com, YOU@YOUR_DOMAIN_NAME",
    :subject => "Hello",
    :text => "Testing some Mailgun awesomness!"
  end
@@ -79,9 +79,9 @@
  	request.AddParameter("domain",
  	                     "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
  	request.Resource = "{domain}/messages";
- 	request.AddParameter("from", "Excited User <YOU@YOUR_DOMAIN_NAME>");
+ 	request.AddParameter("from", "Excited User <mailgun@YOUR_DOMAIN_NAME>");
  	request.AddParameter("to", "bar@example.com");
- 	request.AddParameter("to", "baz@example.com");
+ 	request.AddParameter("to", "YOU@YOUR_DOMAIN_NAME");
  	request.AddParameter("subject", "Hello");
  	request.AddParameter("text", "Testing some Mailgun awesomness!");
  	request.Method = Method.POST;
@@ -93,10 +93,10 @@
  func SendSimpleMessage(domain, apiKey string) (string, error) {
    mg := mailgun.NewMailgun(domain, apiKey, publicApiKey)
    m := mg.NewMessage(
-     "Excited User <YOU@YOUR_DOMAIN_NAME>", 
+     "Excited User <mailgun@YOUR_DOMAIN_NAME>", 
      "Hello", 
      "Testing some Mailgun awesomeness!", 
-     "bar@example.com",
+     "YOU@YOUR_DOMAIN_NAME",
    )
    _, id, err := mg.Send(m)
    return id, err


### PR DESCRIPTION
Change the simple sending instructions to work when users just copy+paste the code into their apps without changing anything.