### PR TITLE
Corrected PHP example in send-template-message.rst

### DIFF
--- a/source/samples/send-template-message.rst
+++ b/source/samples/send-template-message.rst
@@ -44,7 +44,7 @@
   $result = $mgClient->sendMessage($domain, array(
       'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
       'to'      => 'bob@example.com, alice@example.com',
-      'subject' => 'Hello',
+      'subject' => 'Hey, %recipient.first%',
       'text'    => 'If you wish to unsubscribe,
                             click http://mailgun/unsubscribe/%recipient.id%',
               'recipient-variables' => '{"bob@example.com": {"first":"Bob", "id":1},


### PR DESCRIPTION
Corrected PHP example from 'Hello' to expected 'Hey, %recipient.first%'