### PR TITLE
You should not have a @ sign before filepath

### DIFF
--- a/source/samples/send-complex-message.rst
+++ b/source/samples/send-complex-message.rst
@@ -62,7 +62,7 @@
       'text'    => 'Testing some Mailgun awesomness!',
       'html'    => '<html>HTML version of the body</html>'
   ), array(
-      'attachment' => array('@/path/to/file.txt', '@/path/to/file.txt')
+      'attachment' => array('/path/to/file.txt', '/path/to/file.txt')
   ));
 
 .. code-block:: py


### PR DESCRIPTION
The at sign will be removed in Guzzle3: https://github.com/guzzle/guzzle3/blob/master/src/Guzzle/Http/Message/PostFile.php#L47

Aslo, in Guzzle5 it will only cause trouble. So we should not encourage users to add it...