### PR TITLE
removed `from` parameter from PHP example

### DIFF
--- a/source/samples/send-mime-message.rst
+++ b/source/samples/send-mime-message.rst
@@ -39,7 +39,6 @@
   # Make the call to the client.
   $result = $mgClient->sendMessage(
       $domain, array(
-          'from' => 'Excited User <me@samples.mailgun.org>',
           'to'   => 'foo@example.com'
       ),
       '<Pass fully formed MIME string here>'


### PR DESCRIPTION
PHP example is the only one what used `from` parameter. this seems to be unnecessary as it is parsed from message header.
plus none of the other code examples in different languages require `from` parameter