### PR TITLE
Fix minimum PHP version listed for PHP library

### DIFF
--- a/source/libraries.rst
+++ b/source/libraries.rst
@@ -97,7 +97,7 @@ with our API.
 
 Github Repository: `mailgun-php <https://github.com/mailgun/mailgun-php>`_
 
-Minimum PHP Version: 5.3.2
+Minimum PHP Version: 5.4.0
 
 To install the library, you will need to be using Composer in your project.
 If you aren't using Composer yet, it's really simple! Here's how to


### PR DESCRIPTION
The docs indicate that the PHP library can be used on 5.3.x, but the library's `composer.json` file specifies 5.4.0 (probably a result of using Guzzle 5 as a dependency).