### PR TITLE
fix minor typos in libraries

### DIFF
--- a/source/best_practices.rst
+++ b/source/best_practices.rst
@@ -10,7 +10,7 @@ Email Best Practices
 
 This guide is a brief summary of email best practices that we have learned from managing mail servers for thousands of customers and sending (and receiving) a lot of email.   The objective is to help outline what you need to do to have your emails delivered whether or not you use Mailgun.  Of course, if after reading the guide you decide that you have better things to do than maintaining email servers and managing email deliverability, we’d love to help!
 
-In this guide, we will not focus a lot on the content of email messages. That can be paraphrased with a few words: ‘send something people want’ (to paraphrase `Y Combinator's`_ motto). That’s probably the hardest part so apologies for that huge caveat.  Anyways, We will focus on the infrastructure and monitoring of email so that if you are sending something people want, they will get it, and if you are not, you will know about it and hopefully change that.
+In this guide, we will not focus much on the content of email messages. Content can be paraphrased with a few words: ‘send something people want’ (to paraphrase `Y Combinator's`_ motto). Creating good content is probably the hardest part, so apologies for the huge caveat.  Anyways, we focus on the infrastructure and monitoring of email so that if you are sending something people want, they will get it; and if you are not sending something people want, you will know about it and hopefully change that.
 
 
 .. _Word to the Wise: http://blog.wordtothewise.com/

--- a/source/best_practices.rst
+++ b/source/best_practices.rst
@@ -10,7 +10,7 @@ Email Best Practices
 
 This guide is a brief summary of email best practices that we have learned from managing mail servers for thousands of customers and sending (and receiving) a lot of email.   The objective is to help outline what you need to do to have your emails delivered whether or not you use Mailgun.  Of course, if after reading the guide you decide that you have better things to do than maintaining email servers and managing email deliverability, we’d love to help!
 
-In this guide, we will not focus much on the content of email messages. Content can be paraphrased with a few words: ‘send something people want’ (to paraphrase `Y Combinator's`_ motto). Creating good content is probably the hardest part, so apologies for the huge caveat.  Anyways, we focus on the infrastructure and monitoring of email so that if you are sending something people want, they will get it; and if you are not sending something people want, you will know about it and hopefully change that.
+In this guide, we will not focus much on the content of email messages. Content can be paraphrased with a few words: ‘send something people want’ (to paraphrase `Y Combinator's`_ motto). Creating good content is probably the hardest part, so apologies for the huge caveat.  We focus on the infrastructure and monitoring of email so that if you are sending something people want, they will get it; and if you are not sending something people want, you will know about it and hopefully change that.
 
 
 .. _Word to the Wise: http://blog.wordtothewise.com/

--- a/source/faqs.rst
+++ b/source/faqs.rst
@@ -159,9 +159,9 @@ Sending
 Should I use SMTP or the HTTP API?
 **************************************************************************************************************
 
-It's really up to you.  Whatever you find easier is fine with us.  The HTTP API has some advantages, though.  First of all, it's faster.  Second, we think it's easier to use - you don't have to deal with MIME because we will assemble it on our side.  Just use a request library available for your language of choice.
+It's really up to you. Whatever you find easier is fine with us.  The HTTP API has some advantages, however.  First of all, it's faster.  Second, we think it's easier to use - you don't have to deal with MIME because we will assemble it on our side.  Just use a request library available for your language of choice.
 
-Email clients says "sent via mailgun.us" with messages I send.  How do I get rid of this?
+Email clients say "sent via mailgun.us" with messages I send.  How do I get rid of this?
 **************************************************************************************************************
 
 Check the following:

--- a/source/libraries.rst
+++ b/source/libraries.rst
@@ -168,7 +168,7 @@ We also have a step by step tutorial post on `sending email with Node.js <http:/
 cURL
 ====
 `curl <http://linux.die.net/man/1/curl>`_ is a popular command line tool to send HTTP requests.
-It is very simple and yet quite powerfull. With it you could send data using any
+It is very simple and yet quite powerful. With it you could send data using any
 HTTP method. You could send post data and query params and files in a very
 consistent and elegant way. An exellent choice to study the API.
 
@@ -176,7 +176,7 @@ consistent and elegant way. An exellent choice to study the API.
 .. _RESTful: http://en.wikipedia.org/wiki/Representational_State_Transfer
 .. _JSON: http://en.wikipedia.org/wiki/JSON
 .. _Requests: http://docs.python-requests.org/en/latest/index.html
-.. _rest-client: https://github.com/archiloque/rest-client
+.. _rest-client: https://github.com/rest-client/rest-client
 .. _jersey: http://jersey.java.net
 .. _RestSharp: http://restsharp.org
 .. _MultiDict: http://docs.webob.org/en/latest/index.html


### PR DESCRIPTION
1. Misspelling 
2. Invalid/old link that needed to be updated.
3. Grammar and style changes to FAQs/Best Practices