### PR TITLE
Adjust formatting to display Sending Parameters

### DIFF
--- a/source/api-sending.rst
+++ b/source/api-sending.rst
@@ -91,7 +91,7 @@ This makes sense for parameters like ``cc``, ``to`` or ``attachment``.
  v\:my-var             ``v:`` prefix followed by an arbitrary name allows to
                        attach a custom JSON data to the message.
                        See :ref:`manual-customdata` for more information.
- ==================== ==========================================================
+ ===================== ==========================================================
 
 .. code-block:: url
 


### PR DESCRIPTION
Table formatting was broken, so the actual list of available parameters for sending through the API was not being displayed. Small adjustment so that the table shows.