### PR TITLE
Improve PHP sample to show how to check `is_valid`

### DIFF
--- a/source/samples/get-validate.rst
+++ b/source/samples/get-validate.rst
@@ -31,7 +31,8 @@
 
   # Issue the call to the client.
   $result = $mgClient->get("address/validate", array('address' => $validateAddress));
-
+  # is_valid is 0 or 1
+  $isValid = $result->http_response_body->is_valid;
 .. code-block:: py
 
  def get_validate():


### PR DESCRIPTION
It was everything but obvious by looking at the PHP version of https://documentation.mailgun.com/api-email-validation.html#example what the structure of `$result` is. I had to `var_dump` it first to figure that out.