### PR TITLE
Use compare_digest in Python when comparing hex digests

### DIFF
--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -725,10 +725,10 @@ Below is a Python code sample used to verify the signature:
     import hashlib, hmac
 
     def verify(api_key, token, timestamp, signature):
-        return signature == hmac.new(
-                                 key=api_key,
-                                 msg='{}{}'.format(timestamp, token),
-                                 digestmod=hashlib.sha256).hexdigest()
+        hmac_digest = hmac.new(key=api_key,
+                               msg='{}{}'.format(timestamp, token),
+                               digestmod=hashlib.sha256).hexdigest()
+        return hmac.compare_digest(unicode(signature), unicode(hmac_digest))
 
 
 And here's a sample in Ruby:


### PR DESCRIPTION
Doing a `==` comparison for hex digests could lead to timing attack vulnerabilities. By using Python's `compare_digest`, it would do a constant-time check by using byte operations. A timing attack on that would only reveal the length of the hashes, and not the values.

More here: https://codahale.com/a-lesson-in-timing-attacks/
- Ruby and PHP sample codes have to be updated too. I just don't know if there is a built-in library that does constant-time comparison correctly in those languages.
