### PR TITLE
Update attachment size from 25MB to 50MB

### DIFF
--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -162,7 +162,7 @@ When sending via HTTP API, Mailgun offers two options:
 - You can submit the individual parts of your messages to Mailgun, such as text
   and html parts, attachments, and so on. This doesn't require any MIME knowledge on your part.
 
-.. note:: Mailgun supports maximum messages size of 25MB.
+.. note:: Mailgun supports maximum messages size of 50MB.
 
 See :ref:`sending messages <api-sending-messages>` section in our API Reference for a full
 list of message sending options.


### PR DESCRIPTION
The documentation currently specifies an attachment size limit of 25MB, but we've confirmed via ticket 304669 that the actual attachment limit is 50MB.
