### PR TITLE
Fix control panel link (#189)

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -229,7 +229,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       {%- if customsidebar %}
       {% include customsidebar %}
       {%- endif %}
-      <div class="admonition note">You can find your API Key in your <a href="https://{{cp_hostname}}/cp" target="_blank">Control Panel</a></div>
+      <div class="admonition note">You can find your API Key in your <a href="https://mailgun.com/cp" target="_blank">Control Panel</a></div>
     </div>
   </aside>
   {%- endif %}{% endif %}


### PR DESCRIPTION
Variables at the top of the layout template are not working...?

The site is hard-coded everywhere else in the template, so might as well hard-code it for the panel URL as well :)