### PR TITLE
Absolute time difference in PHP code example

### DIFF
--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -750,7 +750,7 @@ And here's a sample in PHP:
     private function verify($apiKey, $token, $timestamp, $signature)
     {
         //check if the timestamp is fresh
-        if (time()-$timestamp>15) {
+        if (abs(time() - $timestamp) > 15) {
             return false;
         }
 


### PR DESCRIPTION
Since we are checking that the timestamp is fresh, we should not assume that the server `time()` will be greater than the `$timestamp` in the received webhook and calculate absolute time difference.

Not doing so could cause timestamps with an arbitrary future date to be considered for validation instead than  discarded.