### PR TITLE
Fix python sample code

### DIFF
--- a/source/samples/send-complex-message.rst
+++ b/source/samples/send-complex-message.rst
@@ -102,8 +102,8 @@
      return requests.post(
          "https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/messages",
          auth=("api", "YOUR_API_KEY"),
-         files=[("attachment", open("files/test.jpg")),
-                ("attachment", open("files/test.txt"))],
+         files=[("attachment", ("test.jpg", open("files/test.jpg").read())),
+                ("attachment", ("test.txt", open("files/test.txt").read()))],
          data={"from": "Excited User <YOU@YOUR_DOMAIN_NAME>",
                "to": "foo@example.com",
                "cc": "baz@example.com",

--- a/source/samples/send-complex-message.rst
+++ b/source/samples/send-complex-message.rst
@@ -102,8 +102,8 @@
      return requests.post(
          "https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/messages",
          auth=("api", "YOUR_API_KEY"),
-         files=[("attachment", ("test.jpg", open("files/test.jpg").read())),
-                ("attachment", ("test.txt", open("files/test.txt").read()))],
+         files=[("attachment", ("test.jpg", open("files/test.jpg","rb").read())),
+                ("attachment", ("test.txt", open("files/test.txt","r").read()))],
          data={"from": "Excited User <YOU@YOUR_DOMAIN_NAME>",
                "to": "foo@example.com",
                "cc": "baz@example.com",

--- a/source/samples/send-complex-message.rst
+++ b/source/samples/send-complex-message.rst
@@ -103,7 +103,7 @@
          "https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/messages",
          auth=("api", "YOUR_API_KEY"),
          files=[("attachment", ("test.jpg", open("files/test.jpg","rb").read())),
-                ("attachment", ("test.txt", open("files/test.txt","r").read()))],
+                ("attachment", ("test.txt", open("files/test.txt","rb").read()))],
          data={"from": "Excited User <YOU@YOUR_DOMAIN_NAME>",
                "to": "foo@example.com",
                "cc": "baz@example.com",


### PR DESCRIPTION
files tuple should be following
('attachment' ,( filename, content, content_type))
or 
('attachment' ,( filename, content))  #when content_type default is application/octet-stream