### PR TITLE
Node.js missing "display: none" element

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -159,7 +159,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           <a href="" id="lang_go" >Go</a>
         </li>
         <li class="lang">
-          <a href="" id="lang_node" >Node.js</a>
+          <a href="" id="lang_js" >Node.js</a>
         </li>
 
         {%- block sidebarsearch %}


### PR DESCRIPTION
The node.js examples aren't currently hidden. Inspector shows the "display: none" is missing from the div class highlight_js. Updating the id from lang_node to lang_js should resolve it.

Just throwing in pics for quick reference:

<img width="521" alt="screen shot 2017-10-10 at 6 23 24 pm" src="https://user-images.githubusercontent.com/5401804/31415277-fb791ba0-ade7-11e7-99c4-af5736dba7a9.png">

<img width="1330" alt="screen shot 2017-10-10 at 6 22 22 pm" src="https://user-images.githubusercontent.com/5401804/31415258-e09a1122-ade7-11e7-9bb2-3e5bf633585a.png">
