### PR TITLE
Domain param errors, remove campaign references, general cleanup

### DIFF
--- a/source/api-campaigns.rst
+++ b/source/api-campaigns.rst
@@ -125,7 +125,7 @@ Stats
 -----
 
 Campaign Stats API allows you to retrieve a campaign performance reports
-similar to what you can see in the control panel.
+similar to what you can see in the Control Panel.
 
 .. code-block:: url
 

--- a/source/api-domains.rst
+++ b/source/api-domains.rst
@@ -26,14 +26,6 @@ Returns a list of domains under your account in JSON. See examples below.
 
 Returns a single domain, including credentials and DNS records. See examples below.
 
-.. container:: ptable
-
- ================= ========================================================
- Parameter         Description
- ================= ========================================================
- name              Name of the domain
- ================= ========================================================
-
 .. code-block:: url
 
      PUT /domains/<domain>/verify
@@ -58,10 +50,12 @@ Create a new domain. See examples below.
  ================= ========================================================
  name              Name of the domain (ex. domain.com)
  smtp_password     Password for SMTP authentication
- spam_action       *disabled* or *tag* Disable, no spam filtering will occur
-                   for inbound messages. Tag, messages will be tagged with a
-                   spam header. See :ref:`um-spam-filter`.
- wildcard          *true* or *false* Determines whether the domain will
+ spam_action       *disabled* or *tag*
+                   Disable, no spam filtering will occur for inbound
+                   messages. Tag, messages will be tagged with a spam
+                   header. See :ref:`um-spam-filter`.
+ wildcard          *true* or *false*
+                   Determines whether the domain will
                    accept email for sub-domains.
  ================= ========================================================
 
@@ -70,14 +64,6 @@ Create a new domain. See examples below.
      DELETE /domains/<domain>
 
 Delete a domain from your account.
-
-.. container:: ptable
-
- ================= ========================================================
- Parameter         Description
- ================= ========================================================
- name              Name of the domain
- ================= ========================================================
 
 .. code-block:: url
 
@@ -90,7 +76,6 @@ Returns a list of SMTP credentials for the defined domain.
  ================= ========================================================
  Parameter         Description
  ================= ========================================================
- name              Name of the domain
  limit             Maximum number of records to return. (100 by default)
  skip              Number of records to skip. (0 by default)
  ================= ========================================================
@@ -106,7 +91,6 @@ Creates a new set of SMTP credentials for the defined domain.
  ================= ==========================================================
  Parameter         Description
  ================= ==========================================================
- name              Name of the domain
  login             The user name, for example ``bob.bar``
  password          A password for the SMTP credentials. (Length Min 5, Max 32)
  ================= ==========================================================
@@ -122,8 +106,6 @@ Updates the specified SMTP credentials. Currently only the password can be chang
  ================= ==========================================================
  Parameter         Description
  ================= ==========================================================
- name              Name of the domain
- login             The user name, for example ``bob.bar``
  password          A password for the SMTP credentials. (Length Min 5, Max 32)
  ================= ==========================================================
 
@@ -137,28 +119,11 @@ Deletes the defined SMTP credentials.
 		  issue no more than 300 requests per minute, per account. See the resultant
 		  rate limit response below.
 
-.. container:: ptable
-
- ================= ==========================================================
- Parameter         Description
- ================= ==========================================================
- name              Name of the domain
- login             The user name, for example ``bob.bar``
- ================= ==========================================================
-
 .. code-block:: url
 
      GET /domains/<domain>/connection
 
 Returns delivery connection settings for the defined domain.
-
-.. container:: ptable
-
- ================= ==========================================================
- Parameter         Description
- ================= ==========================================================
- name              Name of the domain
- ================= ==========================================================
 
 .. code-block:: url
 
@@ -171,25 +136,27 @@ Updates the specified delivery connection settings for the defined domain.
  ================= =============================================================
  Parameter         Description
  ================= =============================================================
- require_tls       If set to `True` this requires the message only be sent over
+ require_tls       *true* or *false*
+                   If set to *true* this requires the message only be sent over
                    a TLS connection. If a TLS connection can not be established,
                    Mailgun will not deliver the message.
 
-                   If set to `False`, Mailgun will still try and upgrade the
+                   If set to *false*, Mailgun will still try and upgrade the
                    connection, but if Mailgun can not, the message will be
                    delivered over a plaintext SMTP connection.
 
                    The default is `False`.
 
- skip_verification If set to `True`, the certificate and hostname will not be
+ skip_verification *true* or *false*
+                   If set to *true*, the certificate and hostname will not be
                    verified when trying to establish a TLS connection and Mailgun
                    will accept any certificate during delivery.
 
-                   If set to `False`, Mailgun will verify the certificate and
+                   If set to *false*, Mailgun will verify the certificate and
                    hostname. If either one can not be verified, a TLS connection
                    will not be established.
 
-                   The default is `False`.
+                   The default is *false*.
  ================= =============================================================
 
 .. code-block:: url
@@ -197,14 +164,6 @@ Updates the specified delivery connection settings for the defined domain.
      GET /domains/<domain>/tracking
 
 Returns tracking settings for a domain.
-
-.. container:: ptable
-
- ================= =============================================================
- Parameter         Description
- ================= =============================================================
- name              Name of the domain (ex. domain.com)
- ================= =============================================================
 
 .. code-block:: url
 
@@ -217,7 +176,7 @@ Updates the open tracking settings for a domain.
  ================= =============================================================
  Parameter         Description
  ================= =============================================================
- name              Name of the domain (ex. domain.com)
+ active            *true* or *false*
  ================= =============================================================
 
 .. code-block:: url
@@ -231,7 +190,13 @@ Updates the click tracking settings for a domain.
  ================= =============================================================
  Parameter         Description
  ================= =============================================================
- name              Name of the domain (ex. domain.com)
+ active            *true*, *false*, or *htmlonly*
+
+                   If set to *true* links will be overwritten and pointed to our
+                   servers so we can track clicks.
+                   
+                   If set to *htmlonly* links will only be rewritten in the HTML
+                   part of a message.
  ================= =============================================================
 
 .. code-block:: url
@@ -245,7 +210,17 @@ Updates unsubscribe tracking settings for a domain.
  ================= =============================================================
  Parameter         Description
  ================= =============================================================
- name              Name of the domain (ex. domain.com)
+ active            *true* or *false*.
+
+ html_footer       Custom HTML version of unsubscribe footer.
+
+ text_footer       Custom text version of unsubscribe footer.
+
+                   Mailgun can automatically provide an unsubscribe footer in
+                   each email you send and also provides you with several
+                   unsubscribe variables. You can customize your unsubscribe
+                   footer by editing the settings in the control panel.
+                   See :ref:`um-tracking-unsubscribes`.
  ================= =============================================================
 
 

--- a/source/api-domains.rst
+++ b/source/api-domains.rst
@@ -176,7 +176,7 @@ Updates the open tracking settings for a domain.
  ================= =============================================================
  Parameter         Description
  ================= =============================================================
- active            *true* or *false*
+ active            ``yes`` or ``no``
  ================= =============================================================
 
 .. code-block:: url
@@ -190,9 +190,9 @@ Updates the click tracking settings for a domain.
  ================= =============================================================
  Parameter         Description
  ================= =============================================================
- active            *true*, *false*, or *htmlonly*
+ active            ``yes``, ``no``, or ``htmlonly``
 
-                   If set to *true* links will be overwritten and pointed to our
+                   If set to *yes* links will be overwritten and pointed to our
                    servers so we can track clicks.
                    
                    If set to *htmlonly* links will only be rewritten in the HTML
@@ -216,11 +216,11 @@ Updates unsubscribe tracking settings for a domain.
 
  text_footer       Custom text version of unsubscribe footer.
 
-                   Mailgun can automatically provide an unsubscribe footer in
+                   *Mailgun can automatically provide an unsubscribe footer in
                    each email you send and also provides you with several
                    unsubscribe variables. You can customize your unsubscribe
-                   footer by editing the settings in the control panel.
-                   See :ref:`um-tracking-unsubscribes`.
+                   footer by editing the settings in the Control Panel.
+                   See :ref:`um-tracking-unsubscribes`.*
  ================= =============================================================
 
 

--- a/source/api-domains.rst
+++ b/source/api-domains.rst
@@ -50,13 +50,17 @@ Create a new domain. See examples below.
  ================= ========================================================
  name              Name of the domain (ex. domain.com)
  smtp_password     Password for SMTP authentication
- spam_action       *disabled* or *tag*
-                   Disable, no spam filtering will occur for inbound
-                   messages. Tag, messages will be tagged with a spam
-                   header. See :ref:`um-spam-filter`.
+ spam_action       ``disabled``, ``block``, or ``tag``
+                   
+                   If *disabled*, no spam filtering will occur for inbound
+                   messages.
+                   
+                   If *block*, inbound spam messages will not be delivered.
+                   
+                   If *tag*, inbound messages will be tagged with a spam header.
+                   See :ref:`um-spam-filter`.
  wildcard          *true* or *false*
-                   Determines whether the domain will
-                   accept email for sub-domains.
+                   Determines whether the domain will accept email for sub-domains.
  ================= ========================================================
 
 .. code-block:: url
@@ -137,17 +141,19 @@ Updates the specified delivery connection settings for the defined domain.
  Parameter         Description
  ================= =============================================================
  require_tls       *true* or *false*
-                   If set to *true* this requires the message only be sent over
+                   
+                   If set to *true*, this requires the message only be sent over
                    a TLS connection. If a TLS connection can not be established,
                    Mailgun will not deliver the message.
 
                    If set to *false*, Mailgun will still try and upgrade the
-                   connection, but if Mailgun can not, the message will be
+                   connection, but if Mailgun cannot, the message will be
                    delivered over a plaintext SMTP connection.
 
                    The default is `False`.
 
  skip_verification *true* or *false*
+                   
                    If set to *true*, the certificate and hostname will not be
                    verified when trying to establish a TLS connection and Mailgun
                    will accept any certificate during delivery.
@@ -192,10 +198,10 @@ Updates the click tracking settings for a domain.
  ================= =============================================================
  active            ``yes``, ``no``, or ``htmlonly``
 
-                   If set to *yes* links will be overwritten and pointed to our
+                   If set to *yes*, links will be overwritten and pointed to our
                    servers so we can track clicks.
                    
-                   If set to *htmlonly* links will only be rewritten in the HTML
+                   If set to *htmlonly*, links will only be rewritten in the HTML
                    part of a message.
  ================= =============================================================
 
@@ -474,7 +480,7 @@ Sample response:
 
 Get tracking settings for a domain:
 
-.. include:: samples/get-tracking.rst
+.. include:: samples/get-domain-tracking.rst
 
 Sample response:
 

--- a/source/api-email-validation.rst
+++ b/source/api-email-validation.rst
@@ -29,7 +29,7 @@ limit of calls per month, which can be changed, to prevent abuse of the public A
 The use of private API endpoints for email validation is encouraged and there is no limit past the initial
 burst per minute rate. It is highly suggested that the private key is used whenever possible.
 
-.. warning:: Do not use your Mailgun private API key on publicly accessible code. Instead, use your Mailgun public key, available in the My Account tab of the Control Panel.
+.. warning:: Do not use your Mailgun private API key on publicly accessible code. Instead, use your Mailgun public key, available in the "Security" tab under the **Account** section of the Control Panel.
 
 .. code-block:: url
 

--- a/source/api-intro.rst
+++ b/source/api-intro.rst
@@ -42,7 +42,7 @@ the domain you're interested in::
 Authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When you sign up for an account, you are given an API key.  You authenticate to the Mailgun API by providing your API key in the request. You can manage your API key in the 'My Account' tab of the Control Panel.
+When you sign up for an account, you are given an API key.  You authenticate to the Mailgun API by providing your API key in the request. You can manage your API key in the "Security" tab under the **Account** section of the Control Panel.
 
 Authentication to the API occurs via `HTTP Basic Auth`_. Use ``api`` as the user
 name and your API key is the password. Here is how you use basic HTTP auth with curl::

--- a/source/api-ips.rst
+++ b/source/api-ips.rst
@@ -5,7 +5,7 @@ IPs
 
 The IP API endpoint allows you to access information regarding the IPs allocated to your Mailgun account that are used for outbound sending.
 
-.. note:: You can manage your IPs from the control panel.
+.. note:: You can manage your IPs from the Control Panel.
           Click on **IP Management** in the settings dropdown menu.
 
 .. code-block:: url

--- a/source/api-routes.rst
+++ b/source/api-routes.rst
@@ -93,7 +93,7 @@ Returns a single route object based on its ID. See examples below.
  ================= ==========================================================
  Parameter         Description
  ================= ==========================================================
- routeId           ID of the route
+ id                ID of the route
  ================= ==========================================================
 
 .. code-block:: url
@@ -129,7 +129,7 @@ only updates the specified fields leaving others unchanged.
  ================= ==========================================================
  Parameter         Description
  ================= ==========================================================
- routeId           ID of the route
+ id                ID of the route
  priority          Integer: smaller number indicates higher priority. Higher
                    priority routes are handled first.
  description       An arbitrary string.
@@ -151,7 +151,7 @@ Deletes a route based on the id.
  ================= ==========================================================
  Parameter         Description
  ================= ==========================================================
- routeId           ID of the route
+ id                ID of the route
  ================= ==========================================================
 
 

--- a/source/api-sending.rst
+++ b/source/api-sending.rst
@@ -50,7 +50,6 @@ This makes sense for parameters like ``cc``, ``to`` or ``attachment``.
                        send inline images (see :ref:`example <inline-image>`).
                        You can post multiple ``inline`` values.
  o\:tag                Tag string. See :ref:`tagging` for more information.
- o\:campaign           Id of the campaign the message belongs to.
  o\:dkim               Enables/disables DKIM signatures on per-message basis.
                        Pass ``yes`` or ``no``
  o\:deliverytime       Desired time of delivery. See :ref:`date-format`. Note:
@@ -115,7 +114,6 @@ to do this. Pass the resulting MIME string as ``message`` parameter.
  message            MIME string of the message. Make sure to use
                     ``multipart/form-data`` to send this as a file upload.
  o\:tag             Tag string. See :ref:`tagging` for more information.
- o\:campaign        Id of the campaign the message belongs to.
  o\:deliverytime    Desired time of delivery. See :ref:`date-format`. Note:
                     Messages can be scheduled for a maximum of 3 days in the
                     future.

--- a/source/api-sending.rst
+++ b/source/api-sending.rst
@@ -50,8 +50,7 @@ This makes sense for parameters like ``cc``, ``to`` or ``attachment``.
                        send inline images (see :ref:`example <inline-image>`).
                        You can post multiple ``inline`` values.
  o\:tag                Tag string. See :ref:`tagging` for more information.
- o\:campaign           Id of the campaign the message belongs to. See
-                       :ref:`um-campaign-analytics` for details.
+ o\:campaign           Id of the campaign the message belongs to.
  o\:dkim               Enables/disables DKIM signatures on per-message basis.
                        Pass ``yes`` or ``no``
  o\:deliverytime       Desired time of delivery. See :ref:`date-format`. Note:
@@ -116,8 +115,7 @@ to do this. Pass the resulting MIME string as ``message`` parameter.
  message            MIME string of the message. Make sure to use
                     ``multipart/form-data`` to send this as a file upload.
  o\:tag             Tag string. See :ref:`tagging` for more information.
- o\:campaign        Id of the campaign the message belongs to. See
-                    :ref:`um-campaign-analytics` for details.
+ o\:campaign        Id of the campaign the message belongs to.
  o\:deliverytime    Desired time of delivery. See :ref:`date-format`. Note:
                     Messages can be scheduled for a maximum of 3 days in the
                     future.

--- a/source/api-tags.rst
+++ b/source/api-tags.rst
@@ -11,8 +11,8 @@ Tags are created on the fly but they are subject to a limit.
 
       GET /<domain>/tags
 
-Returns a list of tags for a domain. Provides with the pagination urls
-if the result set is to long to be returned in a single response.
+Returns a list of tags for a domain. Provides pagination urls
+if the result set is too long to be returned in a single response.
 
 .. container:: ptable
 

--- a/source/best_practices.rst
+++ b/source/best_practices.rst
@@ -130,7 +130,7 @@ You must also process this bounce data and act accordingly.  In addition, many E
 
 Mailgun automatically processes bounce information and reacts accordingly.  A good portion of Mailgun's technology is devoted to the parsing of this feedback and adjusting your sending in accordance with this feedback so that you maintain a good reputation.
 
-If we receive a hard bounce, we will stop sending to that address immediately and will not attempt future deliveries to that address.  We will stop sending to an address after multiple soft bounces, according to the ESPs' guidelines.  It is possible to remove addresses from the flagged list in your control panel or through the API, in case it was a temporary issue.
+If we receive a hard bounce, we will stop sending to that address immediately and will not attempt future deliveries to that address.  We will stop sending to an address after multiple soft bounces, according to the ESPs' guidelines.  It is possible to remove addresses from the flagged list in your Control Panel or through the API, in case it was a temporary issue.
 
 Please see our :ref:`user-manual` for more information.
 

--- a/source/best_practices.rst
+++ b/source/best_practices.rst
@@ -161,7 +161,7 @@ Recipient Engagement
 
 In addition to processing bounces, complaints and unsubscribes, ESPs measure your reputation through the engagement of your recipients.  If recipients are opening, forwarding and replying to your emails, it will improve your reputation.  This is what makes 'do-not-reply' emails so offensive. At many ESPs, it is also helpful if recipients add your email address to their address books.
 
-Mailgun allows you to track opens and link clicks with our Tracking and Campaign functionality (see our :ref:`user-manual` for more information).  You are free to create as many campaigns as you want and use them simultaneously for A/B testing.  In addition, Mailgun is built to receive and parse emails efficiently.  So there is no excuse to not allow your recipients to reply to your emails.  Email is not a billboard - it is a conversant technology.
+Mailgun allows you to track opens and link clicks with our Tracking and Tagging functionality (see our :ref:`user-manual` for more information).  You are free to create up to 4,000 tags and use them simultaneously for A/B testing.  In addition, Mailgun is built to receive and parse emails efficiently.  So there is no excuse to not allow your recipients to reply to your emails.  Email is not a billboard - it is a conversant technology.
 
 Whitelists and other deliverability tools
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/source/faqs.rst
+++ b/source/faqs.rst
@@ -418,20 +418,14 @@ It's up to you.  You can use Mailgun's unsubscribe handling.  You can include ou
 How do I create Campaigns in Mailgun?
 **************************************************************************************************************
 
-It's very simple, just tag your emails with the appropriate header and Mailgun will group all of the events that occur to emails with that tag. Our analytics and campaign reports include those tags as one of the dimensions by which you can view and filter data.  You can have multiple tags per email.  Take a look at our `tagging documentation`_ and `campaign reports documentation`_ for more information.
+It's very simple, just tag your emails with the appropriate ``o:tag`` parameter and Mailgun will group all of the events that occur to emails with that tag. Our analytics reports include those tags as one of the dimensions by which you can view and filter data.  You can have multiple tags per email and up to 4000 total tags.  Take a look at our `tagging documentation`_ for more information.
 
 .. _tagging documentation: http://documentation.mailgun.com/user_manual.html#tagging
-.. _campaign reports documentation: http://documentation.mailgun.com/user_manual.html#campaign-reports
-
-What is the difference between Tracking Stats and Campaign Reports?
-**************************************************************************************************************
-
-Tracking Stats are just event counters that give you an overview of what is happening to your email.  You can see all of the events that are occurring but the only other dimensions are domain and tag.  Campaign reports have other dimensions like recipient domain and time and give you a more in-depth analysis of what is happening with your emails.  In order to group emails for campaigns, you need to use the ``X-Campaign-Id`` header tag.
 
 Do you support A/B testing?
 **************************************************************************************************************
 
-Since creating a campaign is as easy as including an arbitrary tag, yes.  You can easily view which campaign is performing best by viewing the data grouped by tag.
+Since creating a campaign is as easy as including an arbitrary tag, yes.  You can easily view which campaign is performing best by viewing the data grouped by tag in the Analytics tab of the Mailgun control panel.
 
 How do I track which email a recipient has replied to?
 **************************************************************************************************************

--- a/source/faqs.rst
+++ b/source/faqs.rst
@@ -28,13 +28,13 @@ What are the differences between free and paid accounts?
 First of all, for both free and paid accounts, you get 10,000 free messages per month. However, there are some limitations if you don't provide payment information:
 
 * You will not be able to send more than 10,000 messages per month
-* Data retention for logs and the Events API is 2 days.
+* Data retention for logs and the :ref:`Events API <api-events>` is 2 days.
 * The limit for number of domains is 5.
 
 If you do provide payment information:
 
 * There is no limit on the number of emails sent or received.
-* Data retention for Logs and the Events API is 30 days.
+* Data retention for Logs and the :ref:`Events API <api-events>` is 30 days.
 * You can create up to 1,000 domains.
 
 If these limits are not enough for you, or if you need to talk to us about a custom contract, you can reach us at sales@mailgun.com.
@@ -46,9 +46,9 @@ You can find a full list of features on our `pricing page`_.
 Can I get multiple Domains and IP Addresses?
 **************************************************************************************************************
 
-By default we give you one shared IP address. If you would like a dedicated IP address, simply click on the "Upgrade" link in the My Account tab of the control panel. If you want multiple IPs, you can `contact our Support Team <https://mailgun.com/app/support>`_.
+By default we give you one shared IP address. If you would like a dedicated IP address, simply click on the "Add Dedicated IP" button in the **IP Management** section of the Control Panel. You will need to add a credit card to your account first, though, if you have not already done so. If you want multiple IPs, you can `contact our Support Team <https://app.mailgun.com/app/support>`_.
 
-You can create multiple domains in the control panel or through the Domains API (limit of 5 for free accounts and 1,000 for paid accounts).
+You can create multiple domains in the Control Panel or through the :ref:`Domains API <api-domains>`(limit of 5 for free accounts and 1,000 for paid accounts).
 
 Do I need a dedicated IP address?
 **************************************************************************************************************
@@ -64,7 +64,7 @@ The other thing to consider is using separate IPs for your bulk and transactiona
 - Delivery of time-sensitive transactional emails may get queued behind a large batch of bulk/marketing emails.
 - Your transactional mail will be affected by the reputation created by your bulk/marketing mail.
 
-Mailgun's infrastructure mitigates some of the argument's for a dedicated IP address.  First of all, we are constantly monitoring our shared IP addresses for any reputation issues.  We also allow you to schedule delivery of your emails by using the ``o:deliverytime`` parameter.  This allows you to delay the delivery by using a time in the future and also allows you to jump other messages in your queue (say from a large bulk mailing) by using a delivery time of now.
+Mailgun's infrastructure mitigates some of the arguments for a dedicated IP address.  First of all, we are constantly monitoring our shared IP addresses for any reputation issues.  We also allow you to schedule delivery of your emails by using the ``o:deliverytime`` parameter.  This allows you to delay the delivery by using a time in the future and also allows you to jump other messages in your queue (say from a large bulk mailing) by using a delivery time of now.
 
 How do I pick a domain name for my Mailgun account?
 **************************************************************************************************************
@@ -81,7 +81,7 @@ using the same domain in the From field that the actual sender is using.
 There are two types of domains you can configure with Mailgun:
 
 * A sandbox subdomain of mailgun.org. Example: ``sandboxXX.mailgun.org``. This option allows for quick testing, without having to setup DNS entries. This domain is provisioned automatically with every new account. But you can send only to `authorized recipients <https://help.mailgun.com/hc/en-us/articles/217531258>`_.
-* Your own domain like ``mycompany.com``.  This requires you to configure some records at your DNS provider. We provide you with those records and instructions in your control panel.
+* Your own domain like ``mycompany.com``.  This requires you to configure some records at your DNS provider. We provide you with those records and instructions in your Control Panel.
 
 If your company's primary domain is ``mycompany.com``, we recommend the
 following domain names for mailgun:
@@ -99,7 +99,7 @@ order to keep the reputations separate.
 Finally, if you want multiple addresses and you want to direct certain emails
 to certain IP addresses, you will need to have a unique domain or subdomain for
 each IP address.  In this situation, it's best to
-`contact our Support Team <https://mailgun.com/app/support>`_ to discuss your
+`contact our Support Team <https://app.mailgun.com/app/support>`_ to discuss your
 infrastructure.
 
 Can I use the same domain name for Mailgun and for Google Apps (or another email server)?
@@ -127,7 +127,7 @@ If you are using multiple email servers and you want an SPF record for each of t
 How do I know if my DNS records are set up correctly
 **************************************************************************************************************
 
-We have a "Verify Records" button when you click on a domain in the "Domains" tab that will confirm that they are set up correctly and if not, show the incorrect records in red.
+We have a "Check DNS Records Now" button when you click on a domain in the ``Domains`` tab that will confirm that they are set up correctly and, if not, show the incorrect records in red.
 
 You could also use `dig`_ in your command line interface.
 
@@ -143,7 +143,7 @@ Only TLS is supported. Support for SSL has been dropped due to the `POODLE secur
 Ok, everything is set up, how do I start using Mailgun?
 **************************************************************************************************************
 
-Mailgun is primarily a developer's tool so the best way use Mailgun is through our APIs.  They are quite `RESTful`_ and we've tried to make them as intuitive as possible.  Our `Quickstart Guide`_ is a good place to start and you can also use the `API Reference`_ for more detail.  We also expose a lot of the features through the control panel.  The `User Manual`_ is a good place to get a full overview of all of the capabilities of Mailgun.
+Mailgun is primarily a developer's tool so the best way use Mailgun is through our APIs.  They are quite `RESTful`_ and we've tried to make them as intuitive as possible.  Our `Quickstart Guide`_ is a good place to start and you can also use the `API Reference`_ for more detail.  We also expose a lot of the features through the Control Panel.  The `User Manual`_ is a good place to get a full overview of all of the capabilities of Mailgun.
 
 .. _RESTful: http://en.wikipedia.org/wiki/REST
 .. _Quickstart Guide: http://documentation.mailgun.com/quickstart.html
@@ -164,11 +164,11 @@ Email clients say "sent via mailgun.us" with messages I send.  How do I get rid 
 
 Check the following:
 
-* You have a custom domain defined in the "Domains" tab of the Control Panel.
-* You've setup the DKIM DNS record (provided in the Control Panel, "Domains" tab).
+* You have a custom domain defined in the ``Domains`` tab of the Control Panel.
+* You've setup the DKIM DNS record (provided in the Control Panel, ``Domains`` tab).
 * You're authenticating (SMTP) or posting (API) against the custom domain. (e.g. https://api.mailgun.net/v3/youcustomdomain.com/messages)
 
-If you're still seeing "via mailgun.org", please `contact our Support Team <https://mailgun.com/app/support>`_ and we'll investigate.
+If you're still seeing "via mailgun.org", please `contact our Support Team <https://app.mailgun.com/app/support>`_ and we'll investigate.
 
 What is the difference between the "From" and "Sender"
 **************************************************************************************************************
@@ -294,7 +294,7 @@ Why does the amount of email I send matter?
 
 Rate limiting allows ESPs proper time to process and filter spam and ensure that transactional email doesn't get backed up. Without rate limiting in place, ESPs would be even more overwhelmed than they already are. The ESPs all have different sending limits on a per hour, per day basis. Once you hit thresholds with the rate limits, send too much spam, or have any number of other issues, the ISP may start returning error messages. Some ESPs will want you to slow down the sending, stop sending for a period of time, or change your habits (due to bad engagement, bad reputation, etc). We automatically adjust your sending rates according to the feedback from these ESPs to keep you in their good graces.
 
-Generally, these rate limits are on a per IP address basis.  `Contact our Support Team <https://mailgun.com/app/support>`_ if you wish to purchase additional dedicated
+Generally, these rate limits are on a per IP address basis.  `Contact our Support Team <https://app.mailgun.com/app/support>`_ if you wish to purchase additional dedicated
 IP addresses for your account.
 
 Does the amount of email I send from my IP affect my deliverability?
@@ -358,8 +358,9 @@ as both sender and recipient, therefore GMail will not show it.
 In other words GMail does not show you messages you sent to yourself.
 
 The other possibility is that the address had previously experienced a Hard
-Bounce and is on the 'do not send' list.  Check the Bounces tab for a list
-of these addresses and remove the address in question if it is there.
+Bounce and is on the 'do not send' list.  Check the ``Suppressions`` tab of your
+Control Panel for a list of these addresses and remove the address in question if
+it is there.
 
 How do I know if HTTP POST callbacks are coming from Mailgun, and not forged?
 **************************************************************************************************************
@@ -400,7 +401,7 @@ What about Email List Management?
 
 Mailgun does have features to help you with list management.  First of all, we will not deliver again to recipients that
 have hard bounced, unsubscribed, or complained of spam.  This is to maintain your email reputation.  You can remove emails from these
-do not send lists if it was a temporary issue.  You can always access this information via the API or Control panel to update
+do not send lists if it was a temporary issue.  You can always access this information via the API or Control Panel to update
 your lists.
 
 What is the difference between hard and soft bounces and how do you handle them?
@@ -425,7 +426,7 @@ It's very simple, just tag your emails with the appropriate ``o:tag`` parameter 
 Do you support A/B testing?
 **************************************************************************************************************
 
-Since creating a campaign is as easy as including an arbitrary tag, yes.  You can easily view which campaign is performing best by viewing the data grouped by tag in the Analytics tab of the Mailgun control panel.
+Since creating a campaign is as easy as including an arbitrary tag, yes.  You can easily view which campaign is performing best by viewing the data grouped by tag in the ``Analytics`` tab of the Mailgun control panel.
 
 How do I track which email a recipient has replied to?
 **************************************************************************************************************

--- a/source/lower-bounce-rate.rst
+++ b/source/lower-bounce-rate.rst
@@ -9,8 +9,8 @@ The number one reason we see people get blocked is because they have a **bad mai
 
 You can check your `logs`_ to see emails that are bouncing and check your `bounce list`_ for emails that we have stopped sending to as a result of bounces.
 
-.. _logs: https://mailgun.com/cp/log?severity=error
-.. _bounce list: https://mailgun.com/cp/bounces
+.. _logs: https://app.mailgun.com/app/logs
+.. _bounce list: https://app.mailgun.com/app/suppressions
 
 Best practices for lowering bounce rates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -19,13 +19,13 @@ Best practices for lowering bounce rates
 2. Clean your mailing list of invalid email addresses.
 3. Only send emails to recipients that have signed up to receive them.
 4. Verify the email address is correct with a confirmation email (aka, `confirmed opt-in`_).
-5. We recommend using our `free email validator`_ at the point of signup to reduce invalid email addresses.
+5. We recommend using our `Email Validation API`_ at the point of signup to reduce invalid email addresses.
 6. **Don’t** purchase your list or scrape websites for emails.
 
 If your domain does get disabled, `contact support`_ after you have made the recommended changes above so we can re-enable your domain.
 
-.. _Mailgun Control Panel: https://mailgun.com/cp
+.. _Mailgun Control Panel: https://app.mailgun.com/app/dashboard
 .. _confirmed opt-in: http://en.wikipedia.org/wiki/Opt-in_email
-.. _free email validator: http://documentation.mailgun.com/api-email-validation.html
-.. _contact support: https://mailgun.com/app/support
+.. _Email Validation API: http://documentation.mailgun.com/api-email-validation.html
+.. _contact support: https://app.mailgun.com/app/support
 

--- a/source/quickstart-events.rst
+++ b/source/quickstart-events.rst
@@ -112,7 +112,7 @@ In addition to sending, receiving and storing mail, Mailgun can also help
 developers with the following:
 
 - Automatic "Unsubscribe me" functionality.
-- Support for email campaigns and tracking their performance.
+- Support for email campaigns and tracking their performance via tags.
 - Bounce handling.
 - Spam complaints handling.
 - Spam filtering for incoming messages.

--- a/source/quickstart-events.rst
+++ b/source/quickstart-events.rst
@@ -43,7 +43,7 @@ You can access Events through a few interfaces:
 
 * Webhooks (we POST data to your URL).
 * The Events API (you GET data through the API).
-* The Logs Tab of the Control Panel (GUI).
+* The ``Logs`` tab of the Control Panel (GUI).
 
 **Events API**
 

--- a/source/quickstart-sending.rst
+++ b/source/quickstart-sending.rst
@@ -55,7 +55,7 @@ What's actually happening:
 
 You can find your secret API key on your `dashboard`_.
 
-.. _dashboard: https://mailgun.com/app/dashboard
+.. _dashboard: https://app.mailgun.com/app/dashboard
 
 
 Send via SMTP
@@ -67,7 +67,7 @@ Run this:
 
 You can find your SMTP credentials for each domain on your `domains tab`_.
 
-.. _domains tab: https://mailgun.com/app/domains
+.. _domains tab: https://app.mailgun.com/app/domains
 
 Verify Your Domain
 ------------------

--- a/source/razor.rst
+++ b/source/razor.rst
@@ -7,7 +7,7 @@ Razor is Mailgun's reputation system for detecting spammers and phishers as well
 
 If you believe Razor has deactivated your account in error, please contact `Mailgun Support`_ and reference the Razor error code you received to speed up account reactivation.
 
-.. _Mailgun Support: https://mailgun.com/support
+.. _Mailgun Support: https://app.mailgun.com/app/support
 
 ========= ===========================================================
 Code      Reason

--- a/source/samples/add-domain-ip.rst
+++ b/source/samples/add-domain-ip.rst
@@ -95,7 +95,7 @@
 
  // coming soon
 
-.. code-block:: node
+.. code-block:: js
 
  var DOMAIN = 'YOUR_DOMAIN_NAME';
  var mailgun = require('mailgun-js')({ apiKey: "YOUR_API_KEY", domain: DOMAIN });

--- a/source/samples/get-domain-ips.rst
+++ b/source/samples/get-domain-ips.rst
@@ -87,7 +87,7 @@
 
  // coming soon
 
-.. code-block:: node
+.. code-block:: js
 
  var DOMAIN = 'YOUR_DOMAIN_NAME';
  var mailgun = require('mailgun-js')({ apiKey: "YOUR_API_KEY", domain: DOMAIN });

--- a/source/samples/get-domain-tracking.rst
+++ b/source/samples/get-domain-tracking.rst
@@ -1,8 +1,8 @@
 
 .. code-block:: bash
 
- curl -s --user 'api:YOUR_API_KEY' -X DELETE \
-     https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/ips/127.0.0.1
+    curl -s --user 'api:YOUR_API_KEY' -G \
+    https://api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/tracking
 
 .. code-block:: java
 
@@ -15,9 +15,9 @@
  
      // ...
  
-     public static JsonNode deleteDomainIP() throws UnirestException {
+     public static JsonNode getDomainTracking() throws UnirestException {
  
-         HttpResponse<JsonNode> request = Unirest.delete("https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/ips/127.0.0.1")
+         HttpResponse<JsonNode> request = Unirest.get("https://api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME + "/tracking")
              .basicAuth("api", API_KEY)
              .asJson();
  
@@ -34,23 +34,23 @@
   # Instantiate the client.
   $mgClient = new Mailgun('YOUR_API_KEY');
   $domain = 'YOUR_DOMAIN_NAME';
-  $ip = '127.0.0.1';
 
   # Issue the call to the client.
-  $result = $mgClient->delete("$domain/ips/$ip");
+  $result = $mgClient->get("domains/$domain/tracking");
 
 .. code-block:: py
 
- def delete_domain_ip():
-     return requests.delete(
-         "https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/ips/127.0.0.1",
+ def get_domain_tracking():
+     return requests.get(
+         "https://api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/tracking",
          auth=("api", "YOUR_API_KEY"))
 
 .. code-block:: rb
 
- def delete_domain_ip
-   RestClient.delete "https://api:YOUR_API_KEY"\
-   "@api.mailgun.net/v3/YOUR_DOMAIN_NAME/ips/127.0.0.1"
+ def get_domain_tracking
+   RestClient.get("https://api:YOUR_API_KEY"\
+                  "@api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/tracking"\
+                  {|response, request, result| response }
  end
 
 .. code-block:: csharp
@@ -60,15 +60,15 @@
  using RestSharp;
  using RestSharp.Authenticators;
 
- public class DeleteDomainIPChunk
+ public class GetDomainTrackingChunk
  {
 
      public static void Main (string[] args)
      {
-         Console.WriteLine (DeleteDomainIP ().Content.ToString ());
+         Console.WriteLine (GetDomainTracking ().Content.ToString ());
      }
 
-     public static IRestResponse DeleteDomainIP ()
+     public static IRestResponse GetDomainTracking ()
      {
          RestClient client = new RestClient ();
          client.BaseUrl = new Uri ("https://api.mailgun.net/v3");
@@ -77,9 +77,7 @@
                                          "YOUR_API_KEY");
          RestRequest request = new RestRequest ();
          request.AddParameter ("domain", "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
-         request.Resource = "{domain}/ips/{ip}";
-         request.AddUrlSegment ("ip", "127.0.0.1");
-         request.Method = Method.DELETE;
+         request.Resource = "/domains/{domain}/tracking";
          return client.Execute (request);
      }
 
@@ -94,6 +92,6 @@
  var DOMAIN = 'YOUR_DOMAIN_NAME';
  var mailgun = require('mailgun-js')({ apiKey: "YOUR_API_KEY", domain: DOMAIN });
 
- mailgun.delete(`/${DOMAIN}/ips/127.0.0.1`, function (error, body) {
+ mailgun.get(`/domains/${DOMAIN}/tracking`, function (error, body) {
    console.log(body);
  });

--- a/source/samples/get-ip.rst
+++ b/source/samples/get-ip.rst
@@ -87,7 +87,7 @@
 
  // coming soon
 
-.. code-block:: node
+.. code-block:: js
 
  var DOMAIN = 'YOUR_DOMAIN_NAME';
  var mailgun = require('mailgun-js')({ apiKey: "YOUR_API_KEY", domain: DOMAIN });

--- a/source/samples/get-ips.rst
+++ b/source/samples/get-ips.rst
@@ -91,7 +91,7 @@
 
  // coming soon
 
-.. code-block:: node
+.. code-block:: js
 
  var DOMAIN = 'YOUR_DOMAIN_NAME';
  var mailgun = require('mailgun-js')({ apiKey: "YOUR_API_KEY", domain: DOMAIN });

--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -21,7 +21,7 @@ libraries. However, we have written :ref:`libraries` for many popular languages.
 Be sure to check out the additional capabilities provided by using our libraries.
 
 You can also access many Mailgun features through your Mailgun Control
-Panel using your browser and logging in at https://mailgun.com/cp.
+Panel using your browser and logging in at https://app.mailgun.com/app/dashboard.
 
 In addition to the API, Mailgun supports the standard SMTP protocol.  We have included some :ref:`instructions <smtp>` on how to use Mailgun, via SMTP, at the end of the User Manual.
 
@@ -29,7 +29,7 @@ If you are anxious to get started right away, feel free to check
 out the :ref:`quickstart` or :ref:`api-reference`.  There are
 also :ref:`faqs` and :ref:`best-practices` that you can reference.
 
-Finally, always feel free to `contact our Support Team <https://mailgun.com/app/support>`_.
+Finally, always feel free to `contact our Support Team <https://app.mailgun.com/app/support>`_.
 
 Getting Started
 ***************
@@ -63,7 +63,7 @@ There are some limitations if you have not given us your payment information:
 * Data for Logs and the Events API are stored for 2 days.
 
 If you have given us your payment information, there is no limit on number of messages
-sent and/or received and data retention for Logs and the Events API is at least 30 days.
+sent and/or received and data retention for Logs and the :ref:`Events API <api-events>` is at least 30 days.
 
 Verifying Your Domain
 =====================
@@ -122,7 +122,7 @@ please create a support ticket.
 Type      Required  Purpose                     Value
 ========= ========= =========================== =============================================
 TXT       Yes       Domain verification (SPF)   ``v=spf1 include:mailgun.org ~all``
-TXT       Yes       Domain verification (DKIM)  *Find this record in Domain Verification & DNS section in the domain information page for a particular domain in the Mailgun control pannel*
+TXT       Yes       Domain verification (DKIM)  *Find this record in **Domain Verification & DNS** section of the settings page for a particular domain in the Mailgun control pannel*
 CNAME               Enables tracking            ``mailgun.org``
 MX                  Enables receiving           ``10 mxa.mailgun.org``
 MX                  Enables receiving           ``10 mxb.mailgun.org``
@@ -430,7 +430,7 @@ of it is delivered to each subscribed member.
 
 **Managing a list**
 
-You can create Mailing Lists using the ``Mailing List`` tab in the Control Panel or through the API.
+You can create Mailing Lists using the ``Mailing Lists`` tab in the Control Panel or through the API.
 We support a couple of formats to make your life easier:
 you can upload a CSV file with members, use JSON or use form-like file upload.
 
@@ -547,7 +547,7 @@ Mailgun provides a variety of methods to access data on your emails:
 
 - View and search Events through the ``Logs`` tab in the Control Panel to see every event that has happened to every message. You can search by fields like recipient, subject line and even fields that don't show up in the Logs, like message-id. Data is stored for at least 30 days for paid accounts and at least 2 days for free accounts.
 - Access data on Events programmatically through the :ref:`Events API <api-events>`.  Data is stored for at least 30 days for paid accounts and at least 2 days for free accounts.
-- View, search and edit tables for Bounces, Unsubscribes and Spam Complaints in `Suppression Lists <https://mailgun.com/app/suppressions>`_ or their respective APIs (:ref:`Bounces API <api-bounces>`, :ref:`Unsubscribes API <api-unsubscribes>`, :ref:`Complaints API <api-complaints>`). Data is stored indefinitely.
+- View, search and edit tables for Bounces, Unsubscribes and Spam Complaints in the ``Suppressions`` tab of the Control Panel or their respective APIs (:ref:`Bounces API <api-bounces>`, :ref:`Unsubscribes API <api-unsubscribes>`, :ref:`Complaints API <api-complaints>`). Data is stored indefinitely.
 - Access statistics aggregated by tags in the ``Analytics`` tab of the Control Panel or the :ref:`Stats API <api-stats>`. Data is stored for at least 6 months.
 - Receive notifications of events through a `Webhook`_ each time an Event happens and store the data on your side.
 
@@ -555,12 +555,12 @@ Mailgun provides a variety of methods to access data on your emails:
 
 Event tracking is automatically enabled except for Unsubscribes, Opens and Clicks.
 
-You can enable Unsubscribes tracking for your domain via the Domains tab of the Control Panel.
+You can enable Unsubscribes tracking for your domain via the ``Domains`` tab of the Control Panel.
 You can also manage unsubscribes per message by using unsubscribe variables (see `Tracking Unsubscribes`_)
 
 You can enable Opens & Clicks tracking on two levels: per sending domain and per message.
 
-- You can enable Open & Click tracking on per domain basis under the “Domain Settings” subsection on the domain info page.
+- You can enable Open & Click tracking on a per domain basis under the **Tracking Settings** section of a particular domain's settings page.
 - Tracking can also be toggled by setting ``o:tracking``, ``o:tracking-clicks`` and ``o:tracking-opens`` parameters when sending your message. This will override the domain-level setting.
 
 .. note:: You will also have to point CNAME records to mailgun.org for Mailgun to rewrite links and track opens. In addition, there needs to be an html part of message for Mailgun to track opens (see `Tracking Opens`_ and `Tracking Clicks`_ for more detail).
@@ -605,7 +605,7 @@ You can access Events through a few interfaces:
 
 * Webhooks (we POST data to your URL).
 * The Events API (you GET data through the API).
-* The Logs tab of the Control Panel (GUI).
+* The ``Logs`` tab of the Control Panel (GUI).
 
 .. _manual-events-api:
 
@@ -820,7 +820,7 @@ Tracking Opens
 
 Mailgun can keep track of every time a recipient opens your messages. You can see when Opens happen in the ``Logs`` tab or see counters of opens aggregated by tags in the ``Analytics`` tab of the Control Panel.  In addition, you can be notified through a webhook or get the data programmatically through the :ref:`Events API <api-events>`.
 
-You can enable Open tracking in the Tracking Settings section of your domain's settings page in the ``Domains`` tab of your Control Panel or by using the ``o:tracking`` or ``o:tracking-opens`` parameters when sending a message. You will also have to add the appropriate CNAME records to your DNS as specified in the Domain Verification & DNS section, which is also located in your domain's settings page in the ``Domains`` tab of your Control Panel.
+You can enable Open tracking in the **Tracking Settings** section of your domain's settings page in the ``Domains`` tab of your Control Panel or by using the ``o:tracking`` or ``o:tracking-opens`` parameters when sending a message. You will also have to add the appropriate CNAME records to your DNS as specified in the **Domain Verification & DNS** section, which is also located in your domain's settings page in the ``Domains`` tab of your Control Panel.
 
 Opens are tracked by including a transparent .png file, which will only work if there is
 an HTML component to the email (i.e., text only emails will not track opens). You should
@@ -877,7 +877,7 @@ Tracking Clicks
 
 Mailgun can keep track of every time a recipient clicks on links in your messages. You can see when clicks happen in the ``Logs`` tab or see counters of clicks aggregated by tags in the ``Analytics`` tab of the Control Panel.  In addition, you can be notified through a webhook or get the data programmatically through the :ref:`Events API <api-events>`.
 
-You can enable click tracking in the Tracking Settings section of your domain's settings page in the ``Domains`` tab of your Control Panel or by using the ``o:tracking`` or ``o:tracking-clicks`` parameters when sending a message. You will also have to add the appropriate CNAME records to your DNS as specified in the Domain Verification & DNS section, which is also located in your domain's settings page in the ``Domains`` tab of your Control Panel. If you enable Click tracking, links will be overwritten and pointed to our servers so we can track clicks. You can specify that you only want links rewritten in the HTML part of a message with the parameter ``o:tracking-clicks`` and passing ``htmlonly``.
+You can enable click tracking in the **Tracking Settings** section of your domain's settings page in the ``Domains`` tab of your Control Panel or by using the ``o:tracking`` or ``o:tracking-clicks`` parameters when sending a message. You will also have to add the appropriate CNAME records to your DNS as specified in the **Domain Verification & DNS** section, which is also located in your domain's settings page in the ``Domains`` tab of your Control Panel. If you enable Click tracking, links will be overwritten and pointed to our servers so we can track clicks. You can specify that you only want links rewritten in the HTML part of a message with the parameter ``o:tracking-clicks`` and passing ``htmlonly``.
 
 **Clicks Webhook**
 

--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -259,10 +259,6 @@ custom  MIME_ headers listed in the table below.
     X-Mailgun-Tag                 Tag string used for aggregating stats. See :ref:`tagging`
                                   for more information. You can mark a message with several
                                   categories by setting multiple ``X-Mailgun-Tag`` headers.
-    X-Mailgun-Campaign-Id         Id of the campaign the message belongs to. See
-                                  :ref:`um-campaign-analytics` for details.
-                                  You can assign a message to several campaigns by setting
-                                  multiple different ``X-Mailgun-Campaign-Id`` headers.
     X-Mailgun-Dkim                Enables/disables DKIM signatures on per-message basis.
                                   Use ``yes`` or ``no``.
     X-Mailgun-Deliver-By          Desired time of delivery. See `Scheduling Delivery`_ and
@@ -434,7 +430,7 @@ of it is delivered to each subscribed member.
 
 **Managing a list**
 
-You can create Mailing Lists using the Mailing List tab in the Control Panel or through the API.
+You can create Mailing Lists using the ``Mailing List`` tab in the Control Panel or through the API.
 We support a couple of formats to make your life easier:
 you can upload a CSV file with members, use JSON or use form-like file upload.
 
@@ -462,14 +458,6 @@ You can set the access level of Mailing Lists to:
 * Only allow the administrator to post to the list (limited to an API call or authenticated SMTP session);
 * Allow Mailing List members to post to the list; or
 * Allow anybody to post to the list.
-
-**Campaigns**
-
-Mailing lists are integrated with :ref:`um-campaign-analytics`. Each
-message sent to a list with a Campaign ID will be tracked and
-reported. In this case, the mailing list will have detailed analytics for
-all recipients that can be retrieved via API or seen in the Campaign tab of
-the Control Panel.
 
 .. _template-variables:
 
@@ -551,24 +539,23 @@ This is useful for testing purposes.
 Tracking Messages
 *****************
 
-Once you start sending and receiving messages, it's important to track what's happening with them. We try to make tracking your messages as easy as possible through Events, Stats and Campaigns.
+Once you start sending and receiving messages, it's important to track what's happening with them. We try to make tracking your messages as easy as possible through `Events`_, `Stats`_, and `Tagging`_.
 
 In addition, Mailgun permanently stores when a message can not be delivered due to a hard bounce (permanent failure) or when a recipient unsubscribes or complains of spam. In these cases, Mailgun will not attempt to deliver to these recipients in the future, in order to protect your sending reputation.
 
 Mailgun provides a variety of methods to access data on your emails:
 
-- View and search Events through the Logs tab in the Control Panel to see every event that has happened to every message. You can search by fields like recipient, subject line and even fields that don't show up in the Logs, like message-id. Data is stored for at least 30 days for paid accounts and at least 2 days for free accounts.
+- View and search Events through the ``Logs`` tab in the Control Panel to see every event that has happened to every message. You can search by fields like recipient, subject line and even fields that don't show up in the Logs, like message-id. Data is stored for at least 30 days for paid accounts and at least 2 days for free accounts.
 - Access data on Events programmatically through the :ref:`Events API <api-events>`.  Data is stored for at least 30 days for paid accounts and at least 2 days for free accounts.
 - View, search and edit tables for Bounces, Unsubscribes and Spam Complaints in `Suppression Lists <https://mailgun.com/app/suppressions>`_ or their respective APIs (:ref:`Bounces API <api-bounces>`, :ref:`Unsubscribes API <api-unsubscribes>`, :ref:`Complaints API <api-complaints>`). Data is stored indefinitely.
-- Access statistics aggregated by tags in the Tracking tab of the Control Panel or the :ref:`Stats API <api-stats>`. Data is stored for at least 6 months.
-- Create Campaigns and access detailed analytics on those Campaigns through the Control Panel or the :ref:`Campaigns API <api-campaigns>`. Data is stored for at least 6 months other than the delivered event which is stored for 2 weeks.
-- Receive notifications of events through a Webhook each time an Event happens and store the data on your side.
+- Access statistics aggregated by tags in the ``Analytics`` tab of the Control Panel or the :ref:`Stats API <api-stats>`. Data is stored for at least 6 months.
+- Receive notifications of events through a `Webhook`_ each time an Event happens and store the data on your side.
 
 **Enable Tracking**
 
 Event tracking is automatically enabled except for Unsubscribes, Opens and Clicks.
 
-You can enable Unsubscribes tracking for your domain via the "Domains" tab of the Control Panel.
+You can enable Unsubscribes tracking for your domain via the Domains tab of the Control Panel.
 You can also manage unsubscribes per message by using unsubscribe variables (see `Tracking Unsubscribes`_)
 
 You can enable Opens & Clicks tracking on two levels: per sending domain and per message.
@@ -577,6 +564,8 @@ You can enable Opens & Clicks tracking on two levels: per sending domain and per
 - Tracking can also be toggled by setting ``o:tracking``, ``o:tracking-clicks`` and ``o:tracking-opens`` parameters when sending your message. This will override the domain-level setting.
 
 .. note:: You will also have to point CNAME records to mailgun.org for Mailgun to rewrite links and track opens. In addition, there needs to be an html part of message for Mailgun to track opens (see `Tracking Opens`_ and `Tracking Clicks`_ for more detail).
+
+.. _events:
 
 Events
 ======
@@ -616,7 +605,7 @@ You can access Events through a few interfaces:
 
 * Webhooks (we POST data to your URL).
 * The Events API (you GET data through the API).
-* The Logs Tab of the Control Panel (GUI).
+* The Logs tab of the Control Panel (GUI).
 
 .. _manual-events-api:
 
@@ -676,7 +665,7 @@ Sample response:
 Webhooks
 ========
 
-Mailgun can make an HTTP POST to your URLs when events occur with your messages. If you would like Mailgun to POST event notifications, you need to provide a callback URL in the Webhooks tab of the Control Panel. Webhooks are at the domain level so you can provide a unique URL for each domain by using the domain drop down selector.
+Mailgun can make an HTTP POST to your URLs when events occur with your messages. If you would like Mailgun to POST event notifications, you need to provide a callback URL in the ``Webhooks`` tab of the Control Panel. Webhooks are at the domain level so you can provide a unique URL for each domain by using the domain drop down selector.
 
 You can read more about the data that is posted in the appropriate section below (`Tracking Opens`_, `Tracking Clicks`_, `Tracking Unsubscribes`_, `Tracking Spam Complaints`_, `Tracking Bounces`_, `Tracking Failures`_, `Tracking Deliveries`_). We recommend using `<http://bin.mailgun.net/>`_ for creating temporary URLs to test and debug your webhooks.
 
@@ -829,9 +818,9 @@ Supply one or more ``o:tag`` parameters to tag the message.
 Tracking Opens
 ==============
 
-Mailgun can keep track of every time a recipient opens your messages. You can see when Opens happen in the Logs tab or see aggregate counters of opens in the Tracking tab of the Control Panel.  In addition, you can be notified through a webhook or get the data programmatically through the :ref:`Events API <api-events>`.
+Mailgun can keep track of every time a recipient opens your messages. You can see when Opens happen in the ``Logs`` tab or see counters of opens aggregated by tags in the ``Analytics`` tab of the Control Panel.  In addition, you can be notified through a webhook or get the data programmatically through the :ref:`Events API <api-events>`.
 
-You can enable Open tracking by clicking on the checkbox in the Tracking tab of your Control Panel or using the ``o:tracking`` or ``o:tracking-opens`` parameters when sending a message. You will also have to add the appropriate CNAME records to your DNS as specified in the 'Domain' tab of your Control Panel.
+You can enable Open tracking in the Tracking Settings section of your domain's settings page in the ``Domains`` tab of your Control Panel or by using the ``o:tracking`` or ``o:tracking-opens`` parameters when sending a message. You will also have to add the appropriate CNAME records to your DNS as specified in the Domain Verification & DNS section, which is also located in your domain's settings page in the ``Domains`` tab of your Control Panel.
 
 Opens are tracked by including a transparent .png file, which will only work if there is
 an HTML component to the email (i.e., text only emails will not track opens). You should
@@ -842,7 +831,7 @@ show up if the recipient clicks on display images button in his/her email.
 
 **Opens Webhook**
 
-You can specify a webhook URL in the 'Webhooks' tab of your Control Panel. When a user opens
+You can specify a webhook URL in the ``Webhooks`` tab of your Control Panel. When a user opens
 one of your emails, your URL will be called with the following parameters.
 
 .. container:: ptable
@@ -886,13 +875,13 @@ one of your emails, your URL will be called with the following parameters.
 Tracking Clicks
 ===============
 
-Mailgun can keep track of every time a recipient clicks on links in your messages. You can see when clicks happen in the Logs tab or see aggregate counters of clicks in the Tracking tab of the Control Panel.  In addition, you can be notified through a webhook or get the data programmatically through the :ref:`Events API <api-events>`.
+Mailgun can keep track of every time a recipient clicks on links in your messages. You can see when clicks happen in the ``Logs`` tab or see counters of clicks aggregated by tags in the ``Analytics`` tab of the Control Panel.  In addition, you can be notified through a webhook or get the data programmatically through the :ref:`Events API <api-events>`.
 
-You can enable click tracking by clicking on the checkbox in the Tracking tab of your Control Panel or using the ``o:tracking`` or ``o:tracking-clicks`` parameters when sending a message. You will also have to add the appropriate CNAME records to your DNS as specified in the Domains tab of your Control Panel. If you enable Click tracking, links will be overwritten and pointed to our servers so we can track clicks. You can specify that you only want links rewritten in the HTML part of a message with the parameter ``o:tracking-clicks`` and passing ``htmlonly``.
+You can enable click tracking in the Tracking Settings section of your domain's settings page in the ``Domains`` tab of your Control Panel or by using the ``o:tracking`` or ``o:tracking-clicks`` parameters when sending a message. You will also have to add the appropriate CNAME records to your DNS as specified in the Domain Verification & DNS section, which is also located in your domain's settings page in the ``Domains`` tab of your Control Panel. If you enable Click tracking, links will be overwritten and pointed to our servers so we can track clicks. You can specify that you only want links rewritten in the HTML part of a message with the parameter ``o:tracking-clicks`` and passing ``htmlonly``.
 
 **Clicks Webhook**
 
-You can specify a webhook URL in the 'Webhooks' tab of your Control Panel. Every time
+You can specify a webhook URL in the ``Webhooks`` tab of your Control Panel. Every time
 a user clicks on a link inside of your messages, your URL will be called with
 the following parameters:
 
@@ -936,7 +925,7 @@ Mailgun can keep track of every time a recipient requests to be unsubscribed fro
 your mailings.  If you enable unsubscribe tracking, Mailgun will insert unsubscribe links and remove those recipients
 from your mailings automatically for you.
 
-You can see when usubscribes happen in the Logs tab or see aggregate counters of unsubscribes in the Tracking tab of the Control Panel.  In addition, you can be notified through a webhook or get the data programmatically through the :ref:`Events API <api-events>` or the :ref:`Bounces API <api-bounces>`.
+You can see when usubscribes happen in the ``Logs`` tab or see counters of unsubscribes aggregated by tags in the ``Analytics`` tab of the Control Panel.  In addition, you can be notified through a webhook or get the data programmatically through the :ref:`Events API <api-events>` or the :ref:`Bounces API <api-bounces>`.
 
 Mailgun supports three types of unsubscribes: domain, :ref:`tag <tagging>` or :ref:`mailing-lists` levels.
 
@@ -972,7 +961,7 @@ url will be automatically unsubscribed and those email addresses will be blocked
 from receiving future emails from that domain or message tag as appropriate.
 
 Mailgun can automatically provide an unsubscribe footer in each email you send. You can customize
-your unsubscribe footer by editing the settings in the control panel.
+your unsubscribe footer by editing the settings in the Control Panel.
 
 To enable/disable unsubscribes programmaticaly per message you can do the following:
 
@@ -981,7 +970,7 @@ To enable/disable unsubscribes programmaticaly per message you can do the follow
 - Insert a variable in the html and text bodies of your email when you need unsubscribe links.
 - This variable will be replaced by the corresponding unsubscribe link.
 
-In the "Suppressions" tab of the Control Panel or through the API you can also:
+In the ``Suppressions`` tab of the Control Panel or through the API you can also:
 
 - View/get a list of unsubscribed addresses.
 - Remove an unsubscribed address from the list.
@@ -992,7 +981,7 @@ to learn how to programmatically manage lists of unsubscribed users.
 
 **Unsubscribes Webhook**
 
-You can specify a webhook URL in the 'Webhooks' tab of your Control Panel.
+You can specify a webhook URL in the ``Webhooks`` tab of your Control Panel.
 When a user unsubscribes, Mailgun will invoke the webhook with the following parameters:
 
 .. container:: ptable
@@ -1033,7 +1022,7 @@ Tracking Spam Complaints
 Mailgun automatically keeps track of every time a recipient complains that a
 message is spam.
 
-You can see when complaints happen in the Logs tab or see aggregate counters of complaints in the Tracking tab of the Control Panel.  In addition, you can be notified through a webhook or get the data programmatically through the :ref:`Events API <api-events>` or the :ref:`Complaints API <api-complaints>`.
+You can see when complaints happen in the ``Logs`` tab or see counters of complaints, aggregated by tags, in the ``Analytics`` tab of the Control Panel.  In addition, you can be notified through a webhook or get the data programmatically through the :ref:`Events API <api-events>` or the :ref:`Complaints API <api-complaints>`.
 
 Email service providers ("ESPs") are very sensitive to users clicking on spam
 complaint buttons and it's important to monitor that activity to maintain a
@@ -1050,7 +1039,7 @@ manage the lists of users who have complained.
 
 **Spam Complaints Webhook**
 
-You can specify a webhook URL in the 'Webhooks' tab in the control panel.
+You can specify a webhook URL in the ``Webhooks`` tab in the Control Panel.
 When a user reports one of your emails as spam, Mailgun will invoke the
 webhook with the following parameters:
 
@@ -1090,11 +1079,11 @@ following two groups:
 - Hard bounces (permanent failure): Recipient is not found and the recipient
   email server specifies the recipient does not exist. Mailgun stops attempting
   delivery to invalid recipients after one Hard Bounce. These addresses are
-  added to the table in the Bounces tab and Mailgun will not attempt delivery
-  in the future.
+  added to the "Bounces" table in the ``Suppressions`` tab of your Control Panel and Mailgun
+  will not attempt delivery in the future.
 - Soft bounces (temporary failure): Email is not delivered because the mailbox
-  is full or for other reasons. These addresses are not added to the table in
-  the Bounces tab.
+  is full or for other reasons. These addresses are not added to the "Bounces" table in
+  the ``Suppressions`` tab.
 
 With respect to when the recipient SMTP server rejected an incoming message
 Mailgun classifies bounces into the following two groups:
@@ -1115,8 +1104,8 @@ Mailgun classifies bounces into the following two groups:
  email messages won't reach Mailgun. Please refer to
  :ref:`Verifying Your Domain <verifying-your-domain>` for details on how to do that.
 
-You can see when bounces happen in the Logs tab or see aggregate counters of
-bounces in the Tracking tab of the Control Panel. In addition, you can be
+You can see when bounces happen in the ``Logs`` tab or see counters of
+bounces, aggregated by tags, in the ``Analytics`` tab of the Control Panel. In addition, you can be
 notified through a webhook or get the data programmatically through the
 :ref:`Events API <api-events>` or the :ref:`Bounces API <api-bounces>`.
 
@@ -1126,7 +1115,7 @@ manage the lists of hard bounces.
 
 **Bounce Event Webhook**
 
-You can specify a webhook URL in the 'Webhooks' tab of your Control Panel.
+You can specify a webhook URL in the ``Webhooks`` tab of your Control Panel.
 If you do, every time a message experiences a hard bounce, your URL will be invoked with the following parameters:
 
 .. container:: ptable
@@ -1162,11 +1151,11 @@ Tracking Failures
 
 Mailgun tracks all delivery failures. Failures consist of both Hard Bounces (permanent failures) and Soft Bounces (temporary failures).
 
-You can see when failures happen in the Logs tab.  In addition, you can be notified through a webhook when a message is dropped (i.e., stop retries) or get the data programmatically through the :ref:`Events API <api-events>`.
+You can see when failures happen in the ``Logs`` tab.  In addition, you can be notified through a webhook when a message is dropped (i.e., stop retries) or get the data programmatically through the :ref:`Events API <api-events>`.
 
 **Drop Event Webhook**
 
-In the Webhooks tab, you can specify a URL to be notified every time a message is dropped.
+In the ``Webhooks`` tab, you can specify a URL to be notified every time a message is dropped.
 There are a few reasons why Mailgun needs to stop attempting to deliver messages and drop them.
 The most common reason is that Mailgun received a Hard bounce or repeatedly received Soft bounces and continuing attempting to deliver may hurt your reputation with the receiving ESP.  Also, if the address is on one of the 'do not send lists' because that recipient
 had previously bounced, unsubscribed, or complained of spam, we will not attempt delivery and drop the message.  If one of
@@ -1204,11 +1193,11 @@ Tracking Deliveries
 
 Mailgun tracks all successful deliveries of messages. A successful delivery occurs when the recipient email server responds that it has accepted the message.
 
-You can see when deliveries happen in the Logs tab.  In addition, you can be notified through a webhook when a message is delivered or get the data programmatically through the :ref:`Events API <api-events>`.
+You can see when deliveries happen in the ``Logs`` tab.  In addition, you can be notified through a webhook when a message is delivered or get the data programmatically through the :ref:`Events API <api-events>`.
 
 **Delivered Event Webhook**
 
-In the Webhooks tab, you can specify a URL to be notified every time a
+In the ``Webhooks`` tab, you can specify a URL to be notified every time a
 message is delivered. If the message is successfully delivered to the intended
 recipient, we will POST the following parameters to your URL:
 
@@ -1230,12 +1219,14 @@ recipient, we will POST the following parameters to your URL:
 
 .. note:: Unlike other event webhooks (due to frequency of delivered events), Delivered Event will only POST once, right after delivery, and won’t attempt again in case of failure to POST successfully.
 
+.. _stats:
+
 Stats
 =====
 
 Stats provide you with the summary of the events that occur with your messages and can be aggregated by tag, see `Tagging`_ above.
 
-You can see your current statistics in the control panel, or download them using :ref:`the API <api-stats>`
+You can see your current statistics in the Control Panel, or download them using :ref:`the API <api-stats>`
 
 Receiving, Forwarding and Storing Messages
 *******************************************
@@ -1690,7 +1681,7 @@ Spam Filter
 If you are receiving email, you need spam filtering. Mailgun spam filtering is powered
 by an army of SpamAssassin machines. Mailgun gives you three ways to configure spam
 filtering. You can select the appropriate option in the Control Panel when you click
-on a domain name in the 'Domains' tab.
+on a domain name in the ``Domains`` tab.
 
 - Disabled (default)
 - Delete spam (spam is removed and you won’t see it)


### PR DESCRIPTION
*Corrected Domains API tracking params
*Removed most references to campaigns
*Updated references to tabs and other non-existent content within control panel
*Cleaned up some formatting inconsistencies