### PR TITLE
Update domains docs

### DIFF
--- a/source/api-domains.rst
+++ b/source/api-domains.rst
@@ -31,8 +31,7 @@ Returns a single domain, including credentials and DNS records. See examples bel
      PUT /domains/<domain>/verify
 
 Verifies and returns a single domain, including credentials and DNS records.
-If the domain is successfully verified the message should be the following:
-*Domain DNS records have been updated*. For more information on verifying domains,
+If the domain is successfully verified the domain's state will be 'active'. For more information on verifying domains,
 visit the Mailgun `User Manual`_.
 
 .. _User Manual: https://documentation.mailgun.com/en/latest/user_manual.html#verifying-your-domain


### PR DESCRIPTION
"message" is consistently "Domain DNS records have been updated" even when the target domain has not actually been verified.