### PR TITLE
Update user_manual.rst

### DIFF
--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -1272,7 +1272,6 @@ recipient, we will POST the following parameters to your URL:
  signature             String with hexadecimal digits generate by HMAC algorithm (see `securing webhooks`_).
  ==================    ==================================================================================
 
-.. note:: Unlike other event webhooks (due to frequency of delivered events), Delivered Event will only POST once, right after delivery, and won’t attempt again in case of failure to POST successfully.
 
 .. _stats:
 


### PR DESCRIPTION
We've recently updated our system in such a way that we now retry deliveries for delivered events. This change was made in November (according to Josh), however, we didn't update the docs where it said _"Note Unlike other event webhooks (due to frequency of delivered events), Delivered Event will only POST once, right after delivery, and won’t attempt again in case of failure to POST successfully."_