### PR TITLE
Document recipient-variables parameter

### DIFF
--- a/source/api-sending.rst
+++ b/source/api-sending.rst
@@ -89,6 +89,10 @@ This makes sense for parameters like ``cc``, ``to`` or ``attachment``.
  v\:my-var             ``v:`` prefix followed by an arbitrary name allows to
                        attach a custom JSON data to the message.
                        See :ref:`manual-customdata` for more information.
+ recipient-variables   A valid JSON-encoded dictionary, where key is a plain recipient 
+                       address and value is a dictionary with variables that can be 
+                       referenced in the message body. 
+                       See :ref:`batch-sending` for more information.
  ===================== ==========================================================
 
 .. code-block:: url


### PR DESCRIPTION
Include recipient-variables option in the list of parameters for sending via the API