### PR TITLE
Fix code for get-stats for NodeJS

### DIFF
--- a/source/samples/get-stats.rst
+++ b/source/samples/get-stats.rst
@@ -119,6 +119,6 @@
  var DOMAIN = 'YOUR_DOMAIN_NAME';
  var mailgun = require('mailgun-js')({ apiKey: "YOUR_API_KEY", domain: DOMAIN });
 
- mailgun.get(`/${DOMAIN}/stats/total`, {"event": 'accepted', "event": 'delivered', "event": 'failed', "duration": '1m'}, function (error, body) {
+ mailgun.get(`/${DOMAIN}/stats/total`, {"event": ['accepted', 'delivered', 'failed'], "duration": '1m'}, function (error, body) {
    console.log(body);
  });


### PR DESCRIPTION
Error: `event` key cannot be duplicate.
Fix: `event` is supposed to receive an array. Whatever fields we need to get, we add to the list rather than defining duplicate key `event` again and again.