### PR TITLE
Update webhooks documentation, refresh the events examples

### DIFF
--- a/source/api-events.rst
+++ b/source/api-events.rst
@@ -237,6 +237,15 @@ listed the events that you can retrieve using this API.
  delivered         Mailgun sent the email and it was accepted by the recipient
                    email server.
  failed            Mailgun could not deliver the email to the recipient email server.
+                   
+                   severity=permanent when a message is not delivered.
+                   There are several reasons why Mailgun stops attempting to deliver messages
+                   and drops them including: hard bounces, 
+                   messages that reached their retry limit,
+                   previously unsubscribed/bounced/complained addresses,
+                   or addresses rejected by an ESP.
+                   
+                   severity=temporary when a message is temporary rejected by an ESP.
  opened            The email recipient opened the email and enabled image
                    viewing. Open tracking must be enabled in the Mailgun control
                    panel, and the CNAME record must be pointing to mailgun.org.
@@ -286,46 +295,95 @@ Below you can find sample events of various types:
 
     {
       "event": "accepted",
-      "id": "ncV2XwymRUKbPek_MIM-Gw",
-      "timestamp": 1377211256.096436,
-      "tags": [],
+      "id": "jxVuhYlhReaK3QsggHfFRA",
+      "timestamp": 1529692198.641821,
+      "log-level": "info",
+      "method": "smtp",
       "envelope": {
-        "sender": "sender@example.com"
+        "targets": "team@example.org",
+        "transport": "smtp",
+        "sender": "sender@example.org"
       },
-      "campaigns": [],
-      "user-variables": {},
       "flags": {
-        "is-authenticated": false,
-        "is-test-mode": false
+        "is-authenticated": false
       },
-      "routes": [
-        {
-          "priority": 1,
-          "expression": "match_recipient(\".*@samples.mailgun.org\")",
-          "description": "Sample route",
-          "actions": [
-            "stop()",
-            "forward(\"http://host.com/messages\")"
-          ]
-        }
-      ],
       "message": {
-        "headers": {
-          "to": "",
-          "message-id": "77AF5C3CA1416D93FC47AF8AD42A60AD@example.com",
-          "from": "John Doe <sender@example.com>",
+	"headers": {
+	  "to": "team@example.org",
+          "message-id": "20180622182958.1.48906CB188F1A454@exmple.org",
+          "from": "sender@example.org",
           "subject": "Test Subject"
-        },
-        "attachments": [],
-        "recipients": [
-          "recipient@example.com"
-        ],
-        "size": 6021
+	},
+	"attachments": [],
+	"recipients": [
+          "team@example.org"
+	],
+	"size": 586
       },
-      "recipient": "recipient@example.com",
-      "method": "smtp"
+      "storage": {
+	"url": "https://se.api.mailgun.net/v3/domains/example.org/messages/eyJwI...",
+	"key": "eyJwI..."
+      },
+      "recipient": "team@example.org",
+      "recipient-domain": "example.org",
+      "campaigns": [],
+      "tags": [],
+      "user-variables": {}
     }
 
+**Accepted (Routed):**
+
+.. code-block:: javascript
+
+    {
+      "event": "accepted",
+      "id": "cWgTfzV6QQiXY4PqhlLClw",
+      "timestamp": 1529692198.719447,
+      "log-level": "info",
+      "method": "smtp",
+      "routes": [
+	{
+          "expression": "match_recipient(\"team@example.org\")",
+          "id": "5b295a4aa4764a000108508c",
+          "match": {
+    	    "recipient": "team@example.org"
+          }
+	}
+      ],
+      "envelope": {
+	"sender": "sender@example.org",
+	"transport": "smtp",
+	"targets": "john@example.com"
+      },
+      "flags": {
+	"is-routed": true,
+	"is-authenticated": false,
+	"is-system-test": false,
+	"is-test-mode": false
+      },
+      "message": {
+        "headers": {
+          "to": "team@example.org",
+          "message-id": "20180622182958.1.48906CB188F1A454@exmple.org",
+          "from": "sender@exmple.org",
+          "subject": "Test Subject"
+	},
+        "attachments": [],
+        "recipients": [
+          "team@example.org"
+        ],
+        "size": 586
+      },
+      "storage": {
+        "url": "https://se.api.mailgun.net/v3/domains/example.org/messages/eyJwI...",
+        "key": "eyJwI..."
+      },
+      "recipient": "john@example.com",
+      "recipient-domain": "example.com",
+      "campaigns": [],
+      "tags": [],
+      "user-variables": {}
+    }
 
 **Delivered:**
 
@@ -333,82 +391,192 @@ Below you can find sample events of various types:
 
     {
       "event": "delivered",
-      "id": "W3X4JOhFT-OZidZGKKr9iA",
-      "timestamp": 1377208314.173742,
-      "tags": [],
+      "id": "hK7mQVt1QtqRiOfQXta4sw",
+      "timestamp": 1529692199.626182,
+      "log-level": "info",
       "envelope": {
         "transport": "smtp",
-        "sender": "postmaster@samples.mailgun.org",
-        "sending-ip": "184.173.153.199"
+        "sender": "sender@example.org",
+        "sending-ip": "123.123.123.123",
+        "targets": "john@example.com"
+      },
+      "flags": {
+        "is-routed": false,
+        "is-authenticated": false,
+        "is-system-test": false,
+        "is-test-mode": false
       },
       "delivery-status": {
-        "message": "",
-        "code": 0,
-        "description": null
-      },
-      "campaigns": [],
-      "user-variables": {},
-      "flags": {
-        "is-authenticated": true,
-        "is-test-mode": false
+        "tls": true,
+        "mx-host": "aspmx.l.example.com",
+        "code": 250,
+        "description": "",
+        "session-seconds": 0.4367079734802246,
+        "utf8": true,
+        "attempt-no": 1,
+        "message": "OK",
+        "certificate-verified": true
       },
       "message": {
         "headers": {
-          "to": "recipient@example.com",
-          "message-id": "20130822215151.29325.59996@samples.mailgun.org",
-          "from": "sender@example.com",
-          "subject": "Sample Message"
+          "to": "team@example.org",
+          "message-id": "20180622182958.1.48906CB188F1A454@exmple.org",
+          "from": "sender@exmple.org",
+          "subject": "Test Subject"
         },
         "attachments": [],
-        "recipients": [
-          "recipient@example.com"
-        ],
-        "size": 31143
+        "size": 586
       },
-      "recipient": "recipient@example.com",
+      "storage": {
+        "url": "https://se.api.mailgun.net/v3/domains/example.org/messages/eyJwI...",
+        "key": "eyJwI..."
+      },
+      "recipient": "john@example.com",
+      "recipient-domain": "example.com",
+      "campaigns": [],
+      "tags": [],
+      "user-variables": {}
     }
 
-**Failed:**
+**Failed (Permanent):**
 
 .. code-block:: javascript
 
     {
       "event": "failed",
-      "id": "pVqXGJWhTzysS9GpwF2hlQ",
-      "timestamp": 1377198389.769129,
+      "id": "pl271FzxTTmGRW8Uj3dUWw",
+      "timestamp": 1529701969.818328,
+      "log-level": "error",
       "severity": "permanent",
-      "tags": [],
+      "reason": "suppress-bounce",
       "envelope": {
+        "sender": "john@example.org",
         "transport": "smtp",
-        "sender": "postmaster@samples.mailgun.org",
-        "sending-ip": "184.173.153.199"
+        "targets": "joan@example.com"
+      },
+      "flags": {
+        "is-routed": false,
+        "is-authenticated": true,
+        "is-system-test": false,
+        "is-test-mode": false
       },
       "delivery-status": {
-        "message": "Relay Not Permitted",
-        "code": 550,
-        "description": null
+        "attempt-no": 1,
+        "message": "",
+        "code": 605,
+        "description": "Not delivering to previously bounced address",
+        "session-seconds": 0.0
       },
+      "message": {
+        "headers": {
+          "to": "joan@example.com",
+          "message-id": "20180622211249.1.2A6098970A380E12@example.org",
+          "from": "john@example.org",
+          "subject": "Test Subject"
+        },
+        "attachments": [],
+        "size": 867
+      },
+      "storage": {
+        "url": "https://se.api.mailgun.net/v3/domains/example.org/messages/eyJwI...",
+        "key": "eyJwI..."
+      },
+      "recipient": "slava@mailgun.com",
+      "recipient-domain": "mailgun.com",
       "campaigns": [],
+      "tags": [],
+      "user-variables": {}
+    }
+
+**Failed (Permanent, Delayed Bounce):**
+
+.. code-block:: javascript
+
+    {
+      "event": "failed"
+      "id": "igw2SXYxTOabezGjqA9_xw",
+      "timestamp": 1529700261.747814,
+      "log-level": "error",
+      "severity": "permanent",
       "reason": "bounce",
-      "user-variables": {},
+      "delivery-status": {
+        "message": "smtp; 550-5.1.1 The email account that you tried to reach does not exist.",
+        "code": "5.1.1",
+        "description": ""
+      },
       "flags": {
-        "is-authenticated": true,
+        "is-delayed-bounce": true,
         "is-test-mode": false
       },
       "message": {
         "headers": {
-          "to": "recipient@example.com",
-          "message-id": "20130822185902.31528.73196@samples.mailgun.org",
-          "from": "John Doe <sender@example.com>",
+          "to": "joan@example.com",
+          "message-id": "20180521184023.49972.E75804E1DC9E5F16@example.org",
+          "from": "john@example.org",
           "subject": "Test Subject"
         },
         "attachments": [],
-        "recipients": [
-          "recipient@example.com"
-        ],
-        "size": 557
+        "size": 771
+      },  
+      "recipient": "joan@example.com",
+      "campaigns": [],
+      "tags": [],
+      "user-variables": {},
+    }
+
+**Failed (Temporary):**
+
+.. code-block:: javascript
+
+    {
+      "event": "failed",
+      "id": "U2kZkAiuScqcMTq-8Atz-Q",
+      "timestamp": 1529439955.794033,
+      "log-level": "warn",
+      "severity": "temporary",
+      "reason": "generic",
+      "envelope": {
+        "transport": "smtp",
+        "sender": "john@example.org",
+        "sending-ip": "123.123.123.123",
+        "targets": "joan@example.com"
       },
-      "recipient": "recipient@example.com",
+      "flags": {
+        "is-routed": false,
+        "is-authenticated": true,
+        "is-system-test": false,
+        "is-test-mode": false
+      },
+      "delivery-status": {
+        "tls": true,
+        "mx-host": "mx.example.com",
+        "code": 421,
+        "description": "",
+        "session-seconds": 0.09020090103149414,
+        "retry-seconds": 600,
+        "attempt-no": 1,
+        "message": "4.4.2 mxfront9g.mail.example.com Error: timeout exceeded",
+        "certificate-verified": true
+      },
+      "message": {
+        "headers": {
+          "to": "joan@example.com",
+          "message-id": "20180619202554.1.C370AA02DD7DDF22@example.org",
+          "from": "john@example.org",
+          "subject": "Test Subject"
+        },
+        "attachments": [],
+        "size": 810
+      },
+      "storage": {
+        "url": "https://se.api.mailgun.net/v3/domains/example.org/messages/eyJwI...",
+        "key": "eyJwI..."
+      },
+      "recipient": "joan@example.com",
+      "recipient-domain": "example.com",
+      "campaigns": [],
+      "tags": [],
+      "user-variables": {}
     }
 
 **Opened:**
@@ -419,6 +587,7 @@ Below you can find sample events of various types:
       "event": "opened",
       "id": "-laxIqj9QWubsjY_3pTq_g",
       "timestamp": 1377047343.042277,
+      "log-level": "info",
       "recipient": "recipient@example.com",
       "geolocation": {
         "country": "US",
@@ -453,6 +622,7 @@ Below you can find sample events of various types:
       "event": "clicked",
       "id": "G5zMz2ysS6OxZ2C8xb2Tqg",
       "timestamp": 1377075564.094891,
+      "log-level": "info",
       "recipient": "recipient@example.com",
       "geolocation": {
         "country": "US",
@@ -460,8 +630,8 @@ Below you can find sample events of various types:
         "city": "Austin"
       },
       "tags": [],
-      "url": "http://google.com",
-      "ip": "127.0.0.1",
+      "url": "http://example.com/signup",
+      "ip": "123.123.123.321",
       "campaigns": [],
       "user-variables": {},
       "client-info": {
@@ -486,6 +656,7 @@ Below you can find sample events of various types:
       "event": "unsubscribed",
       "id": "W3X4JOhFT-OZidZGKKr9iA",
       "timestamp": 1377213791.421473,
+      "log-level": "info",
       "recipient": "recipient@example.com",
       "geolocation": {
         "country": "US",
@@ -495,7 +666,7 @@ Below you can find sample events of various types:
       "campaigns": [],
       "tags": [],
       "user-variables": {},
-      "ip": "50.51.14.451",
+      "ip": "23.23.23.345",
       "client-info": {
         "client-type": "browser",
         "client-os": "OS X",
@@ -518,6 +689,7 @@ Below you can find sample events of various types:
       "event": "complained",
       "id": "ncV2XwymRUKbPek_MIM-Gw",
       "timestamp": 1377214260.049634,
+      "log-level": "warn",
       "recipient": "foo@example.com",
       "tags": [],
       "campaigns": [],
@@ -543,34 +715,65 @@ Below you can find sample events of various types:
 .. code-block:: javascript
 
     {
-       "event":"stored",
-       "id": "czsjqFATSlC3QtAK-C80nw",
-       "timestamp":1378335036.859382,
-       "storage":{
-          "url":"https://api.mailgun.net/v3/domains/ninomail.com/messages/WyI3MDhjODgwZTZlIiwgIjF6",
-          "key":"WyI3MDhjODgwZTZlIiwgIjF6"
-       },
-       "campaigns":[],
-       "user-variables":{},
-       "flags":{
-          "is-test-mode":false
-       },
-       "tags":[],
-       "message":{
-          "headers":{
-             "to":"satshabad <satshabad@mailgun.com>",
-             "message-id":"CAC8xyJxAO7Y0sr=3r-rJ4C6ULZs3cSVPPqYEXLHtarKOKaOCKw@mail.gmail.com",
-             "from":"Someone <someone@example.com>",
-             "subject":"Re: A TEST"
-          },
-          "attachments":[],
-          "recipients":[
-             "satshabad@mailgun.com"
-          ],
-          "size":2566
-       },
+      "event": "stored",
+      "id": "WRVmVc47QYi4DHth_xpRUA",
+      "timestamp": 1529692198.691758,
+      "log-level": "info",
+      "flags": {
+        "is-test-mode": false
+      },
+      "message": {
+        "headers": {
+          "to": "team@example.org",
+          "message-id": "20180622182958.1.48906CB188F1A454@exmple.org",
+          "from": "sender@example.org",
+          "subject": "Test Subject"
+        },
+        "attachments": [],
+        "recipients": [
+          "team@example.org"
+        ],
+        "size": 586
+      },
+      "storage": {
+        "url": "https://se.api.mailgun.net/v3/domains/example.org/messages/eyJwI...",
+        "key": "eyJwI..."
+      },
+      "campaigns": [],
+      "tags": [],
+      "user-variables": {}
     }
 
+**Rejected:**
+
+.. code-block:: javascript
+
+    {
+      "event": "rejected"
+      "id": "OMTXD3-sSmKIQa1gSKkYVA",
+      "timestamp": 1529704976.104692,
+      "log-level": "warn",
+      "flags": {
+        "is-test-mode": false
+      },
+      "reject": {
+        "reason": "Sandbox subdomains are for test purposes only. Please add your own domain or add the address to authorized recipients in Account Settings.",
+        "description": ""
+      },
+      "message": {
+        "headers": {
+          "to": "joan@example.org",
+          "message-id": "20180622220256.1.B31A451A2E5422BB@sandbox55887fac92de874df5ae0023b75fd62f1d.mailgun.org",
+          "from": "john@sandbox55887fac92de874df5ae0023b75fd62f1d.mailgun.org",
+          "subject": "Test Subject"
+        },
+        "attachments": [],
+        "size": 867
+      },
+      "campaigns": [],
+      "tags": [],
+      "user-variables": {}
+    }
 
 Examples
 --------

--- a/source/api-events.rst
+++ b/source/api-events.rst
@@ -262,6 +262,8 @@ listed the events that you can retrieve using this API.
  stored            Mailgun has stored an incoming message
  ================= ============================================================
 
+.. _api-events-structure:
+
 Event Structure
 ---------------
 

--- a/source/api-suppressions.rst
+++ b/source/api-suppressions.rst
@@ -27,7 +27,7 @@ Subsequent delivery attempts to an address found in a bounce list are prevented
 to protect your sending reputation.
 
 Mailgun can notify your application every time a message bounces via
-a :ref:`bounce webhook <um-tracking-bounces>`.
+a :ref:`permanent_fail webhook <um-tracking-failures>`.
 
 View all bounces
 ----------------
@@ -253,7 +253,7 @@ emails without any programming on your end. You can enable this in your
 Control Panel under your domain settings.
 
 Mailgun can notify your application every time a user unsubscribes via
-an :ref:`unsubscribe webhook <um-tracking-unsubscribes>`.
+an :ref:`unsubscribed webhook <um-tracking-unsubscribes>`.
 
 View all unsubscribes
 ---------------------
@@ -449,7 +449,7 @@ Complaint list stores email addresses of recipients who marked your messages
 as a spam (for ESPs that support FBL).
 
 Mailgun can notify your application every time a recipient flags your message
-as spam via a :ref:`complaint webhook <um-tracking-spam-complaints>`.
+as spam via a :ref:`complained webhook <um-tracking-spam-complaints>`.
 
 View all complaints
 -------------------

--- a/source/api-webhooks-deprecated.rst
+++ b/source/api-webhooks-deprecated.rst
@@ -3,10 +3,16 @@
 Webhooks (deprecated)
 =====================
 
-**Note:** This refers to a previous version of the API which is deprecated
-and may be removed in a future release. Ongoing development of webhooks
-should be using the latest API available here: :ref:`api-webhooks`
- 
+.. Warning:: This refers to a previous version of the API which is deprecated
+          and may be removed in a future release. Ongoing development of webhooks
+          should be using the latest API available here: :ref:`api-webhooks`
+
+.. Note:: If you are looking forward to migrate to the new Webhooks API, 
+          you don’t need to worry: both APIs can be used at the same time.
+          You’ll be notified by the legacy webhooks and the new webhooks.
+          But don’t forget to remove the legacy url as soon as you get migrated your app to the new API!
+
+
 This API allows you to create, access, and delete webhooks programmatically.
 
 Supported webhooks, and their documentation, are listed below:
@@ -14,13 +20,13 @@ Supported webhooks, and their documentation, are listed below:
 ================= ========================================================
 Webhook Name      Documentation
 ================= ========================================================
-bounce            :ref:`um-tracking-bounces`
-deliver		        :ref:`um-tracking-deliveries`
-drop			        :ref:`um-tracking-failures`
-spam              :ref:`um-tracking-spam-complaints`
-unsubscribe       :ref:`um-tracking-unsubscribes`
-click             :ref:`um-tracking-clicks`
-open              :ref:`um-tracking-opens`
+bounce            :ref:`um-tracking-failures`, :ref:`api-bounces-webhook-data-format`
+deliver           :ref:`um-tracking-deliveries`, :ref:`api-deliveries-webhook-data-format`
+drop              :ref:`um-tracking-failures`, :ref:`api-drops-webhook-data-format`
+spam              :ref:`um-tracking-spam-complaints`, :ref:`api-spam-webhook-data-format`
+unsubscribe       :ref:`um-tracking-unsubscribes`, :ref:`api-unsubscribes-webhook-data-format`
+click             :ref:`um-tracking-clicks`, :ref:`api-clicks-webhook-data-format`
+open              :ref:`um-tracking-opens`, :ref:`api-opens-webhook-data-format`
 ================= ========================================================
 
 
@@ -106,8 +112,252 @@ Deletes an existing webhook.
  id                Name of the webhook. (See above for supported webhooks)
  ================= ========================================================
 
+Webhooks Parameters
+-----------------
+
+.. _api-opens-webhook-data-format:
+
+Opens Parameters
+~~~~~~~~~~~~~~~~
+You can specify a webhook URL programmaticaly using the API described above or in the ``Webhooks`` tab of your Control Panel. When a user opens
+one of your emails, your URL will be called with the following parameters.
+
+.. container:: ptable
+
+ ==================    ==================================================================================
+ Parameter Name        Description
+ ==================    ==================================================================================
+ event                 Event name ("opened").
+ recipient             Recipient who opened.
+ domain                Domain that sent the original message.
+ ip                    IP address the event originated from.
+ country               Two-letter `country code`_ (as specified by `ISO3166`_) the event came from or
+                       'unknown' if it couldn't be determined.
+ region                Two-letter or two-digit `region code`_ or 'unknown' if it couldn't be determined.
+ city                  Name of the city the event came from or 'unknown' if it couldn't be determined.
+ user-agent            `User agent`_ string of the client triggered the event.
+ device-type           Device type the email was opened on. Can be 'desktop', 'mobile', 'tablet', 'other'
+                       or 'unknown'.
+ client-type           Type of software the email was opened in, e.g. 'browser', 'mobile browser',
+                       'email client'.
+ client-name           Name of the client software, e.g. 'Thunderbird', 'Chrome', 'Firefox'.
+ client-os             OS family running the client software, e.g. 'Linux', 'Windows', 'OSX'.
+ campaign-id           The id of campaign triggering the event.
+ campaign-name         The name of campaign triggering the event.
+ tag                   Message tag, if message was tagged. See :ref:`tagging`
+ mailing-list          The address of mailing list the original message was sent to.
+ "custom variables"    Your own custom JSON object included in the header (see :ref:`manual-customdata`).
+ timestamp             Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
+ token                 Randomly generated string with length 50 (see `securing webhooks`_).
+ signature             String with hexadecimal digits generate by HMAC algorithm (see `securing webhooks`_).
+ ==================    ==================================================================================
+
+.. _api-clicks-webhook-data-format:
+
+Clicks Parameters
+~~~~~~~~~~~~~~~~~
+You can specify a webhook URL programmaticaly using the API described above or 
+in the ``Webhooks`` tab of your Control Panel. Every time a user clicks on a link
+inside of your messages, your URL will be called with the following parameters:
+
+.. container:: ptable
+
+ ==================    ==================================================================================
+ Parameter Name        Description
+ ==================    ==================================================================================
+ event                 Event name ("clicked").
+ recipient             Recipient who clicked.
+ domain                Domain that sent the original message.
+ ip                    IP address the event originated from.
+ country               Two-letter `country code`_ (as specified by `ISO3166`_) the event came from or
+                       'unknown' if it couldn't be determined.
+ region                Two-letter or two-digit `region code`_ or 'unknown' if it couldn't be determined.
+ city                  Name of the city the event came from or 'unknown' if it couldn't be determined.
+ user-agent            `User agent`_ string of the client triggered the event.
+ device-type           Device type the link was clicked on. Can be 'desktop', 'mobile', 'tablet', 'other'
+                       or 'unknown'.
+ client-type           Type of software the link was opened in, e.g. 'browser', 'mobile browser',
+                       'email client'.
+ client-name           Name of the client software, e.g. 'Thunderbird', 'Chrome', 'Firefox'.
+ client-os             OS family running the client software, e.g. 'Linux', 'Windows', 'OSX'.
+ campaign-id           The id of campaign triggering the event.
+ campaign-name         The name of campaign triggering the event.
+ tag                   Message tag, if it was tagged. See :ref:`tagging`.
+ url                   The URL that was clicked.
+ mailing-list          The address of mailing list the original message was sent to.
+ "custom variables"    Your own custom JSON object included in the header (see :ref:`manual-customdata`).
+ timestamp             Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
+ token                 Randomly generated string with length 50 (see `securing webhooks`_).
+ signature             String with hexadecimal digits generate by HMAC algorithm (see `securing webhooks`_).
+ ==================    ==================================================================================
+
+.. _api-unsubscribes-webhook-data-format:
+
+Unsubscribes Parameters
+~~~~~~~~~~~~~~~~~~~~~~~
+You can specify a webhook URL programmaticaly using the API described above or 
+in the ``Webhooks`` tab of your Control Panel.
+When a user unsubscribes, Mailgun will invoke the webhook with the following parameters:
+
+.. container:: ptable
+
+ ==================    ==================================================================================
+ Parameter Name        Description
+ ==================    ==================================================================================
+ event                 Event name ("unsubscribed").
+ recipient             Recipient who unsubscribed.
+ domain                Domain that sent the original message.
+ ip                    IP address the event originated from.
+ country               Two-letter `country code`_ (as specified by `ISO3166`_) the event came from or
+                       'unknown' if it couldn't be determined.
+ region                Two-letter or two-digit `region code`_ or 'unknown' if it couldn't be determined.
+ city                  Name of the city the event came from or 'unknown' if it couldn't be determined.
+ user-agent            `User agent`_ string of the client triggered the event.
+ device-type           Device type the person unsubscribed on. Can be 'desktop', 'mobile', 'tablet', 'other'
+                       or 'unknown'.
+ client-type           Type of software the unsubscribe link was clicked in, e.g. 'browser', 'mobile browser',
+                       'email client'.
+ client-name           Name of the client software, e.g. 'Thunderbird', 'Chrome', 'Firefox'.
+ client-os             OS family running the client software, e.g. 'Linux', 'Windows', 'OSX'.
+ campaign-id           The id of the campaign that recipient has unsubscribed from.
+ campaign-name         The name of campaign triggering the event.
+ tag                   Message tag, if it was tagged. See :ref:`tagging`.
+ mailing-list          The address of mailing list the original message was sent to.
+ "custom variables"    Your own custom JSON object included in the header (see :ref:`manual-customdata`).
+ timestamp             Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
+ token                 Randomly generated string with length 50 (see `securing webhooks`_).
+ signature             String with hexadecimal digits generate by HMAC algorithm (see `securing webhooks`_).
+ ==================    ==================================================================================
+
+.. _api-spam-webhook-data-format:
+
+Spam Complaints Parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+You can specify a webhook URL programmaticaly using the API described above or 
+in the ``Webhooks`` tab in the Control Panel.
+When a user reports one of your emails as spam, Mailgun will invoke the
+webhook with the following parameters:
+
+.. container:: ptable
+
+ ==================    ==================================================================================
+ Parameter Name        Description
+ ==================    ==================================================================================
+ event                 Event name ("complained").
+ recipient             Recipient who clicked spam.
+ domain                Domain that sent the original message.
+ message-headers       String list of all MIME headers of the original message dumped to a JSON string (order of headers preserved).
+ campaign-id           The id of campaign triggering the event.
+ campaign-name         The name of campaign triggering the event.
+ tag                   Message tag, if it was tagged. See :ref:`tagging`.
+ mailing-list          The address of mailing list the original message was sent to.
+ "custom variables"    Your own custom JSON object included in the header (see :ref:`manual-customdata`).
+ timestamp             Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
+ token                 Randomly generated string with length 50 (see `securing webhooks`_).
+ signature             String with hexadecimal digits generate by HMAC algorithm (see `securing webhooks`_).
+ attachment-x          attached file (‘x’ stands for number of the attachment). Attachments are
+                       included if the recipient ESP includes them in the bounce message. They are
+                       handled as file uploads, encoded as multipart/form-data.
+ ==================    ==================================================================================
+
+.. _api-bounces-webhook-data-format:
+
+Bounces Parameters
+~~~~~~~~~~~~~~~~~~
+You can specify a webhook URL programmaticaly using the API described above or 
+in the ``Webhooks`` tab of your Control Panel.
+If you do, every time a message experiences a hard bounce, your URL will be invoked with the following parameters:
+
+.. container:: ptable
+
+ ======================    ===========================================================================
+ Parameter Name            Description
+ ======================    ===========================================================================
+ event                     Event name ("bounced").
+ recipient                 Recipient who could not be reached.
+ domain                    Domain that sent the original message.
+ message-headers           String list of all MIME headers of the original message dumped to a JSON string (order of headers preserved).
+ code                      SMTP bounce error code in form (X.X.X).
+ error                     SMTP bounce error string.
+ notification              Detailed reason for bouncing (optional).
+ campaign-id               The id of campaign triggering the event.
+ campaign-name             The name of campaign triggering the event.
+ tag                       Message tag, if it was tagged. See :ref:`tagging`.
+ mailing-list              The address of mailing list the original message was sent to.
+ "custom variables"        Your own custom JSON object included in the header (see :ref:`manual-customdata`).
+ timestamp                 Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
+ token                     Randomly generated string with length 50 (see `securing webhooks`_).
+ signature                 String with hexadecimal digits generate by HMAC algorithm
+                           (see `securing webhooks`_).
+ attachment-x              attached file (‘x’ stands for number of the attachment). Attachments are
+                           included if the recipient ESP includes them in the bounce message. They are
+                           handled as file uploads, encoded as multipart/form-data.
+ ======================    ===========================================================================
+
+.. _api-drops-webhook-data-format:
+
+Drops Parameters
+~~~~~~~~~~~~~~~~
+In the ``Webhooks`` tab or programmaticaly using the API described above,
+you can specify a URL to be notified every time a message is dropped.
+There are a few reasons why Mailgun needs to stop attempting to deliver messages and drop them.
+The most common reason is that Mailgun received a Hard bounce or repeatedly received Soft bounces 
+and continuing attempting to deliver may hurt your reputation with the receiving ESP.
+Also, if the address is on one of the 'do not send lists' because that recipient had previously 
+bounced, unsubscribed, or complained of spam, we will not attempt delivery and drop the message.
+If one of these events occur we will POST the following parameters to your URL:
+
+.. container:: ptable
+
+ ==================    ==================================================================================
+ Parameter Name        Description
+ ==================    ==================================================================================
+ event                 Event name ("dropped").
+ recipient             Intended recipient.
+ domain                Domain that sent the original message.
+ message-headers       String list of all MIME headers of the original message dumped to a JSON string (order of headers preserved).
+ reason                Reason for failure. Can be one either "hardfail" or "old". See below.
+ code                  ESP response code, e.g. if the message was blocked as a spam (optional).
+ description           Detailed explanation of why the messages was dropped
+ "custom variables"    Your own custom JSON object included in the header (see :ref:`manual-customdata`).
+ timestamp             Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
+ token                 Randomly generated string with length 50 (see `securing webhooks`_).
+ signature             String with hexadecimal digits generate by HMAC algorithm (see `securing webhooks`_).
+ attachment-x          attached file (‘x’ stands for number of the attachment). Attachments are
+                       included if the recipient ESP includes them in the bounce message. They are
+                       handled as file uploads, encoded as multipart/form-data.
+ ==================    ==================================================================================
+
+- ``old`` indicates that Mailgun tried to deliver the message unsuccessfully for more than 8 hours.
+- ``hardfail`` not delivering to an address that previously bounced, unsubscribed, or complained.
+
+.. _api-deliveries-webhook-data-format:
+
+Deliveries Parameters
+~~~~~~~~~~~~~~~~~~~~~
+In the ``Webhooks`` tab or programmaticaly using the API described above, you can specify 
+a URL to be notified every time a message is delivered. 
+If the message is successfully delivered to the intended recipient, 
+we will POST the following parameters to your URL:
+
+.. container:: ptable
+
+ ==================    ==================================================================================
+ Parameter Name        Description
+ ==================    ==================================================================================
+ event                 Event name ("delivered").
+ recipient             Intended recipient.
+ domain                Domain that sent the original message.
+ message-headers       String list of all MIME headers dumped to a JSON string (order of headers preserved).
+ Message-Id            String id of the original message delivered to the recipient.
+ "custom variables"    Your own custom JSON object included in the header of the original message (see :ref:`manual-customdata`).
+ timestamp             Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
+ token                 Randomly generated string with length 50 (see `securing webhooks`_).
+ signature             String with hexadecimal digits generate by HMAC algorithm (see `securing webhooks`_).
+ ==================    ==================================================================================
+ 
 Examples
-~~~~~~~~
+--------
 
 Return a list of webhooks set for the specified domain.
 

--- a/source/api-webhooks.rst
+++ b/source/api-webhooks.rst
@@ -5,6 +5,7 @@ Webhooks
 
 This API allows you to create, access, and delete webhooks programmatically.
 
+.. note::  A previous version of the API is described here :ref:`api-webhooks-deprecated`
 
 Supported webhooks, and their documentation, are listed below:
 
@@ -56,7 +57,7 @@ Returns details about a the webhook specified in the URL.
 
 Creates a new webhook.
 
-.. note:: When adding a Click or Open webhook, ensure that you also have tracking enabled.
+.. note:: When adding a Clicked or Opened webhook, ensure that you also have tracking enabled.
 
 .. container:: ptable
 
@@ -117,11 +118,13 @@ Sample response:
 	{
 	  "webhooks": {
 	    "opened": {
-	      "urls": [ "http://postbin.heroku.com/860bcd65",
-		            "http://postbin.heroku.com/860bcd65" ]
+	      "urls": [
+		        "https://your_domain.com/v1/opened",
+		        "https://your_domain.com/v2/opened" 
+		      ]
 	    },
 	    "clicked": {
-	      "urls": [ "http://postbin.heroku.com/860bcd65" ]
+	      "urls": [ "https://your_domain.com/v1/clicked" ]
 	    }
 	  }
 	}
@@ -136,7 +139,7 @@ Sample response:
 
 	{
 	  "webhook": {
-	    "urls": [ "http://google.com" ]
+	    "urls": [ "https://your_domain.com/v1/clicked" ]
 	  }
 	}
 
@@ -151,9 +154,11 @@ Sample response:
 	{
 	  "message": "Webhook has been created",
 	  "webhook": {
-	    "urls": [ "http://bin.example.com/8de4a9c4",
-                  "http://bin.example.com/8de4a9c5",
-				  "http://bin.example.com/8de4a9c6" ]
+	    "urls": [
+		      "https://your_domain.com/v1/clicked",
+		      "https://your_domain.com/v2/clicked",
+		      "https://your_partner_domain.com/v1/clicked" 
+		    ]
 	  }
 	}
 
@@ -168,7 +173,7 @@ Sample response:
 	{
 	  "message": "Webhook has been updated",
 	  "webhook": {
-	    "urls": [ "http://google.com" ]
+	    "urls": [ "https://your_domain.com/v1/clicked" ]
 	  }
 	}
 
@@ -183,9 +188,11 @@ Sample response:
 	{
 	  "message": "Webhook has been deleted",
 	  "webhook": {
-	    "urls": [ "http://postbin.heroku.com/860bcd65",
-		          "http://postbin.heroku.com/860bcd65",
-				  "http://postbin.heroku.com/860bcd65" ]
+	    "urls": [
+		      "https://your_domain.com/v1/clicked",
+		      "https://your_domain.com/v2/clicked",
+		      "https://your_partner_domain.com/v1/clicked" 
+		    ]
 	  }
 	}
 

--- a/source/api_reference.rst
+++ b/source/api_reference.rst
@@ -15,6 +15,5 @@ API Reference
    api-suppressions
    api-routes
    api-webhooks
-   api-webhooks-deprecated
    api-mailinglists
    api-email-validation

--- a/source/samples/add-webhook.rst
+++ b/source/samples/add-webhook.rst
@@ -3,9 +3,9 @@
     curl -s --user 'api:YOUR_API_KEY' \
 	https://api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/webhooks \
 	-F id='clicked' \
-	-F url='http://bin.example.com/8de4a9c4'
-	-F url='http://bin.example.com/8de4a9c5'
-	-F url='http://bin.example.com/8de4a9c6'
+	-F url='https://your_domain.com/v1/clicked'
+	-F url='https://your_domain.com/v2/clicked'
+	-F url='https://your_partner_domain.com/v1/clicked'
 
 .. code-block:: java
 
@@ -20,15 +20,15 @@
  
      public static JsonNode addWebhook() throws UnirestException {
  
-         HttpResponse <JsonNode> request = Unirest.post("https://api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME + "/webhooks")
+         HttpResponse <JsonNode> request = Unirest.post("https://api.mailgun.net/v3/domains/" + 
+                                                        YOUR_DOMAIN_NAME + 
+                                                        "/webhooks")
  		      .basicAuth("api", API_KEY)
- 			  .field("id","click")
- 		      .field("url", { 
-                   "http://bin.example.com/8de4a9c4", 
-                   "http://bin.example.com/8de4a9c5", 
-                   "http://bin.example.com/8de4a9c6" 
-              })
- 		      .asJson();
+ 		      .field("id","click")
+ 		      .field("url", "https://your_domain.com/v1/clicked")
+ 		      .field("url", "https://your_domain.com/v2/clicked")
+ 		      .field("url", "https://your_partner_domain.com/v1/clicked")
+              }).asJson();
  
          return request.getBody();
      }
@@ -48,9 +48,9 @@
   $result = $mgClient->post("domains/$domain/webhooks", array(
       'id'  => 'clicked',
       'url' => array(
-          'http://bin.example.com/8de4a9c4',
-          'http://bin.example.com/8de4a9c5',
-          'http://bin.example.com/8de4a9c6'
+          'https://your_domain.com/v1/clicked',
+          'https://your_domain.com/v2/clicked',
+          'https://your_partner_domain.com/v1/clicked'
       )
   ));
 
@@ -62,9 +62,9 @@
          auth=("api", "YOUR_API_KEY"),
          data={
            'id':'clicked', 
-           'url':[ 'http://bin.example.com/8de4a9c4',            
-		     'http://bin.example.com/8de4a9c5',
-		     'http://bin.example.com/8de4a9c6'
+           'url':[ 'https://your_domain.com/v1/clicked',
+		   'https://your_domain.com/v2/clicked',
+		   'https://your_partner_domain.com/v1/clicked'
            ]
          })
 
@@ -74,9 +74,9 @@
    RestClient.post("https://api:YOUR_API_KEY"\
                    "@api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/webhooks",
                    :id => 'clicked',
-                   :url => ['http://bin.example.com/8de4a9c4',
-                            'http://bin.example.com/8de4a9c5',
-                            'http://bin.example.com/8de4a9c6'])
+                   :url => ['https://your_domain.com/v1/clicked',
+                            'https://your_domain.com/v2/clicked',
+                            'https://your_partner_domain.com/v1/clicked'])
  end
 
 .. code-block:: csharp
@@ -104,11 +104,9 @@
          RestRequest request = new RestRequest ();
          request.Resource = "domains/YOUR_DOMAIN_NAME/webhooks";
          request.AddParameter ("id", "clicked");
-         request.AddParameter ("url", new [] { 
-              "http://bin.example.com/8de4a9c4", 
-              "http://bin.example.com/8de4a9c5", 
-              "http://bin.example.com/8de4a9c6"
-         });
+         request.AddParameter ("url", "https://your_domain.com/v1/clicked")
+         request.AddParameter ("url", "https://your_domain.com/v2/clicked")
+         request.AddParameter ("url", "https://your_partner_domain.com/v1/clicked")
          request.Method = Method.POST;
          return client.Execute (request);
      }
@@ -119,14 +117,15 @@
 
  func CreateWebhook(domain, apiKey string) error {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.CreateWebhook("deliver", "http://www.example.com")
+   return mg.CreateWebhook("clicked", "https://your_domain.com/v1/clicked")
  }
 
 .. code-block:: js
 
  var DOMAIN = 'YOUR_DOMAIN_NAME';
  var mailgun = require('mailgun-js')({ apiKey: "YOUR_API_KEY", domain: DOMAIN });
+ var urls = ['https://your_domain.com/v1/clicked', 'https://your_domain.com/v2/clicked', 'https://your_parner_domain.com/v1/clicked']
 
- mailgun.post(`/domain/${DOMAIN}/webhooks`, {"id": 'clicked', "url": ['http://bin.example.com/8de4a9c4, http://bin.example.com/8de4a9c5, http://bin.example.com/8de4a9c6'}, function (error, body) {
+ mailgun.post(`/domain/${DOMAIN}/webhooks`, {"id": 'clicked', "url": urls}, function (error, body) {
    console.log(body);
  });

--- a/source/samples/delete-webhook.rst
+++ b/source/samples/delete-webhook.rst
@@ -87,7 +87,7 @@
 
  func DeleteWebhook(t *testing.T) {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.DeleteWebhook("deliver")
+   return mg.DeleteWebhook("clicked")
  }
 
 .. code-block:: js

--- a/source/samples/get-webhook.rst
+++ b/source/samples/get-webhook.rst
@@ -36,7 +36,7 @@
   $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
-  $result = $mgClient->get("$domain/webhooks/click");
+  $result = $mgClient->get("$domain/webhooks/clicked");
 
 .. code-block:: py
 
@@ -87,7 +87,7 @@
 
  func GetWebhook(domain, apiKey string) (string, error) {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.GetWebhookByType("deliver")
+   return mg.GetWebhookByType("clicked")
  }
 
 .. code-block:: js

--- a/source/samples/update-webhook.rst
+++ b/source/samples/update-webhook.rst
@@ -3,7 +3,7 @@
 
     curl -s --user 'api:YOUR_API_KEY' -X PUT \
 	https://api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/webhooks/clicked \
-	-F url='http://google.com'
+	-F url='https://your_domain,com/v1/clicked'
 
 .. code-block:: java
 
@@ -20,7 +20,7 @@
 
          HttpResponse <JsonNode> request = Unirest.put("https://api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME + "/webhooks/clicked")
              .basicAuth("api", API_KEY)
-             .field("url", "http://google.com")
+             .field("url", "https://your_domain.com/clicked")
              .asJson();
 
          return request.getBody();
@@ -40,24 +40,23 @@
 
   # Issue the call to the client.
   $result = $mgClient->put("$domain/webhooks/clicked", array(
-      'url' => 'http://google.com'
+      'url' => 'https://your_domain.com/clicked'
   ));
 
 .. code-block:: py
 
- def update_member():
+ def update_webhook():
      return requests.put(
          ("https://api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/webhooks/clicked"),
          auth=('api', 'YOUR_API_KEY'),
-         data={'url': 'http://google.com'})
+         data={'url': 'https://your_domain.com/clicked'})
 
 .. code-block:: rb
 
- def update_member
+ def update_webhook
    RestClient.put("https://api:YOUR_API_KEY" \
-                  "@api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/webhooks/clicked" \
-                  "/bar@example.com",
-                  :url => 'http://google.com')
+                  "@api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/webhooks/clicked",
+                  :url => 'https://your_domain.com/clicked')
  end
 
 .. code-block:: csharp
@@ -84,7 +83,7 @@
                                          "YOUR_API_KEY");
          RestRequest request = new RestRequest ();
          request.Resource = "/domains/YOUR_DOMAIN_NAME/webhooks/clicked";
-         request.AddParameter ("url", "http://google.com");
+         request.AddParameter ("url", "https://your_domain.com/clicked");
          request.Method = Method.PUT;
          return client.Execute (request);
      }
@@ -95,7 +94,7 @@
 
  func UpdateWebhook(domain, apiKey string) error {
    mg := mailgun.NewMailgun(domain, apiKey, "")
-   return mg.UpdateWebhook("deliver", "http://api.example.com")
+   return mg.UpdateWebhook("clicked", "https://your_domain.com/clicked")
  }
 
 .. code-block:: js
@@ -103,6 +102,6 @@
  var DOMAIN = 'YOUR_DOMAIN_NAME';
  var mailgun = require('mailgun-js')({ apiKey: "YOUR_API_KEY", domain: DOMAIN });
 
- mailgun.put(`/domain/${DOMAIN}/webhooks/clicked`, {"url": 'http://google.com'}, function (error, body) {
+ mailgun.put(`/domain/${DOMAIN}/webhooks/clicked`, {"url": 'https://your_domain.com/v1/clicked'}, function (error, body) {
    console.log(body);
  });

--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -715,14 +715,14 @@ Sample response:
     }
   }
 
-.. _webhooks:
+.. _OBwebhooks:
 
 Webhooks
 ========
 
 Mailgun can make an HTTP POST to your URLs when events occur with your messages. If you would like Mailgun to POST event notifications, you need to provide a callback URL in the ``Webhooks`` tab of the Control Panel. Webhooks are at the domain level so you can provide a unique URL for each domain by using the domain drop down selector.
 
-You can read more about the data that is posted in the appropriate section below (`Tracking Opens`_, `Tracking Clicks`_, `Tracking Unsubscribes`_, `Tracking Spam Complaints`_, `Tracking Bounces`_, `Tracking Failures`_, `Tracking Deliveries`_). We recommend using `<http://bin.mailgun.net/>`_ for creating temporary URLs to test and debug your webhooks.
+You can read more about the data that is posted in the appropriate section below (`Tracking Opens`_, `Tracking Clicks`_, `Tracking Unsubscribes`_, `Tracking Spam Complaints`_, `Tracking Failures`_, `Tracking Deliveries`_). We recommend using `<http://bin.mailgun.net/>`_ for creating temporary URLs to test and debug your webhooks.
 
 For Webhook POSTs, Mailgun listens for the following codes from your server and reacts accordingly:
 
@@ -734,6 +734,34 @@ If your application is unable to process the webhook request but you do not retu
 
 The Webhooks API endpoint allows you to programmatically manipulate the webhook
 URLs defined for a specific domain. Head over to the :ref:`api-webhooks` API endpoint documentation.
+
+.. _webhooks payload:
+
+**Payload**
+
+When something has happened to your email, your URL will be called with application/json payload
+and with the following data:
+
+.. code-block:: javascript
+
+  {
+    “signature”:
+    {
+      "timestamp": "1529006854",
+      "token": "a8ce0edb2dd8301dee6c2405235584e45aa91d1e9f979f3de0",
+      "signature": "d2271d12299f6592d9d44cd9d250f0704e4674c30d79d07c47a66f95ce71cf55"
+    }
+    “event-data”:
+    {
+      "event": "opened",
+      "timestamp": 1529006854.329574,
+      "id": "DACSsAdVSeGpLid7TN03WA",
+      ...
+    }
+  }
+
+The 'signature' parameters are described in `securing webhooks`_
+and the 'event-data' parameters are the same as described in :ref:`api-events-structure`
 
 .. _securing webhooks:
 
@@ -886,38 +914,8 @@ show up if the recipient clicks on display images button in his/her email.
 
 **Opens Webhook**
 
-You can specify a webhook URL in the ``Webhooks`` tab of your Control Panel. When a user opens
-one of your emails, your URL will be called with the following parameters.
-
-.. container:: ptable
-
- ==================    ==================================================================================
- Parameter Name        Description
- ==================    ==================================================================================
- event                 Event name ("opened").
- recipient             Recipient who opened.
- domain                Domain that sent the original message.
- ip                    IP address the event originated from.
- country               Two-letter `country code`_ (as specified by `ISO3166`_) the event came from or
-                       'unknown' if it couldn't be determined.
- region                Two-letter or two-digit `region code`_ or 'unknown' if it couldn't be determined.
- city                  Name of the city the event came from or 'unknown' if it couldn't be determined.
- user-agent            `User agent`_ string of the client triggered the event.
- device-type           Device type the email was opened on. Can be 'desktop', 'mobile', 'tablet', 'other'
-                       or 'unknown'.
- client-type           Type of software the email was opened in, e.g. 'browser', 'mobile browser',
-                       'email client'.
- client-name           Name of the client software, e.g. 'Thunderbird', 'Chrome', 'Firefox'.
- client-os             OS family running the client software, e.g. 'Linux', 'Windows', 'OSX'.
- campaign-id           The id of campaign triggering the event.
- campaign-name         The name of campaign triggering the event.
- tag                   Message tag, if message was tagged. See :ref:`tagging`
- mailing-list          The address of mailing list the original message was sent to.
- "custom variables"    Your own custom JSON object included in the header (see :ref:`manual-customdata`).
- timestamp             Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
- token                 Randomly generated string with length 50 (see `securing webhooks`_).
- signature             String with hexadecimal digits generate by HMAC algorithm (see `securing webhooks`_).
- ==================    ==================================================================================
+You can specify webhook URLs programmaticaly using the :ref:`api-webhooks` API.
+When a user opens one of your emails, your ``opened`` URLs will be called with the following `webhooks payload`_.
 
 .. _Return Path: http://www.returnpath.net/
 .. _country code: http://dev.maxmind.com/static/csv/codes/iso3166.csv
@@ -936,40 +934,8 @@ You can enable click tracking in the **Tracking Settings** section of your domai
 
 **Clicks Webhook**
 
-You can specify a webhook URL in the ``Webhooks`` tab of your Control Panel. Every time
-a user clicks on a link inside of your messages, your URL will be called with
-the following parameters:
-
-.. container:: ptable
-
- ==================    ==================================================================================
- Parameter Name        Description
- ==================    ==================================================================================
- event                 Event name ("clicked").
- recipient             Recipient who clicked.
- domain                Domain that sent the original message.
- ip                    IP address the event originated from.
- country               Two-letter `country code`_ (as specified by `ISO3166`_) the event came from or
-                       'unknown' if it couldn't be determined.
- region                Two-letter or two-digit `region code`_ or 'unknown' if it couldn't be determined.
- city                  Name of the city the event came from or 'unknown' if it couldn't be determined.
- user-agent            `User agent`_ string of the client triggered the event.
- device-type           Device type the link was clicked on. Can be 'desktop', 'mobile', 'tablet', 'other'
-                       or 'unknown'.
- client-type           Type of software the link was opened in, e.g. 'browser', 'mobile browser',
-                       'email client'.
- client-name           Name of the client software, e.g. 'Thunderbird', 'Chrome', 'Firefox'.
- client-os             OS family running the client software, e.g. 'Linux', 'Windows', 'OSX'.
- campaign-id           The id of campaign triggering the event.
- campaign-name         The name of campaign triggering the event.
- tag                   Message tag, if it was tagged. See :ref:`tagging`.
- url                   The URL that was clicked.
- mailing-list          The address of mailing list the original message was sent to.
- "custom variables"    Your own custom JSON object included in the header (see :ref:`manual-customdata`).
- timestamp             Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
- token                 Randomly generated string with length 50 (see `securing webhooks`_).
- signature             String with hexadecimal digits generate by HMAC algorithm (see `securing webhooks`_).
- ==================    ==================================================================================
+You can specify webhook URLs programmaticaly using the :ref:`api-webhooks` API.
+Every time a user clicks on a link inside of your messages, your ``clicked`` URLs will be called with the following `webhooks payload`_.
 
 .. _um-tracking-unsubscribes:
 
@@ -1036,38 +1002,8 @@ to learn how to programmatically manage lists of unsubscribed users.
 
 **Unsubscribes Webhook**
 
-You can specify a webhook URL in the ``Webhooks`` tab of your Control Panel.
-When a user unsubscribes, Mailgun will invoke the webhook with the following parameters:
-
-.. container:: ptable
-
- ==================    ==================================================================================
- Parameter Name        Description
- ==================    ==================================================================================
- event                 Event name ("unsubscribed").
- recipient             Recipient who unsubscribed.
- domain                Domain that sent the original message.
- ip                    IP address the event originated from.
- country               Two-letter `country code`_ (as specified by `ISO3166`_) the event came from or
-                       'unknown' if it couldn't be determined.
- region                Two-letter or two-digit `region code`_ or 'unknown' if it couldn't be determined.
- city                  Name of the city the event came from or 'unknown' if it couldn't be determined.
- user-agent            `User agent`_ string of the client triggered the event.
- device-type           Device type the person unsubscribed on. Can be 'desktop', 'mobile', 'tablet', 'other'
-                       or 'unknown'.
- client-type           Type of software the unsubscribe link was clicked in, e.g. 'browser', 'mobile browser',
-                       'email client'.
- client-name           Name of the client software, e.g. 'Thunderbird', 'Chrome', 'Firefox'.
- client-os             OS family running the client software, e.g. 'Linux', 'Windows', 'OSX'.
- campaign-id           The id of the campaign that recipient has unsubscribed from.
- campaign-name         The name of campaign triggering the event.
- tag                   Message tag, if it was tagged. See :ref:`tagging`.
- mailing-list          The address of mailing list the original message was sent to.
- "custom variables"    Your own custom JSON object included in the header (see :ref:`manual-customdata`).
- timestamp             Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
- token                 Randomly generated string with length 50 (see `securing webhooks`_).
- signature             String with hexadecimal digits generate by HMAC algorithm (see `securing webhooks`_).
- ==================    ==================================================================================
+You can specify webhook URLs programmaticaly using the :ref:`api-webhooks` API.
+When a user unsubscribes, Mailgun will invoke ``unsubscribed`` webhook with the following `webhooks payload`_.
 
 .. _um-tracking-spam-complaints:
 
@@ -1092,41 +1028,20 @@ Spam Complaint tracking is always enabled.
 Mailgun provides :ref:`Spam complaints API <api-complaints>` to programmatically
 manage the lists of users who have complained.
 
-**Spam Complaints Webhook**
+**Spam Complains Webhook**
 
-You can specify a webhook URL in the ``Webhooks`` tab in the Control Panel.
-When a user reports one of your emails as spam, Mailgun will invoke the
-webhook with the following parameters:
+You can specify webhook URLs programmaticaly using the :ref:`api-webhooks` API.
+When a user reports one of your emails as spam, Mailgun will invoke ``complained`` webhook with the following `webhooks payload`_.
 
-.. container:: ptable
+.. _um-tracking-failures:
 
- ==================    ==================================================================================
- Parameter Name        Description
- ==================    ==================================================================================
- event                 Event name ("complained").
- recipient             Recipient who clicked spam.
- domain                Domain that sent the original message.
- message-headers       String list of all MIME headers of the original message dumped to a JSON string (order of headers preserved).
- campaign-id           The id of campaign triggering the event.
- campaign-name         The name of campaign triggering the event.
- tag                   Message tag, if it was tagged. See :ref:`tagging`.
- mailing-list          The address of mailing list the original message was sent to.
- "custom variables"    Your own custom JSON object included in the header (see :ref:`manual-customdata`).
- timestamp             Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
- token                 Randomly generated string with length 50 (see `securing webhooks`_).
- signature             String with hexadecimal digits generate by HMAC algorithm (see `securing webhooks`_).
- attachment-x          attached file (‘x’ stands for number of the attachment). Attachments are
-                       included if the recipient ESP includes them in the bounce message. They are
-                       handled as file uploads, encoded as multipart/form-data.
- ==================    ==================================================================================
+Tracking Failures
+=================
 
-.. _um-tracking-bounces:
+Mailgun tracks all delivery failures.
+Failures consist of both Hard Bounces (permanent failures) and Soft Bounces (temporary failures).
 
-Tracking Bounces
-================
-
-An email message is said to "bounce" if it is rejected by the recipient SMTP
-server.
+An email message is said to "bounce" if it is rejected by the recipient SMTP server.
 
 With respect to failure persistence Mailgun classifies bounces into the
 following two groups:
@@ -1167,78 +1082,20 @@ notified through a webhook or get the data programmatically through the
 Mailgun provides :ref:`Bounces API <api-bounces>` to programmatically
 manage the lists of hard bounces.
 
+**Permanent Failure Webhook**
 
-**Bounce Event Webhook**
-
-You can specify a webhook URL in the ``Webhooks`` tab of your Control Panel.
-If you do, every time a message experiences a hard bounce, your URL will be invoked with the following parameters:
-
-.. container:: ptable
-
- ======================    ===========================================================================
- Parameter Name            Description
- ======================    ===========================================================================
- event                     Event name ("bounced").
- recipient                 Recipient who could not be reached.
- domain                    Domain that sent the original message.
- message-headers           String list of all MIME headers of the original message dumped to a JSON string (order of headers preserved).
- code                      SMTP bounce error code in form (X.X.X).
- error                     SMTP bounce error string.
- notification              Detailed reason for bouncing (optional).
- campaign-id               The id of campaign triggering the event.
- campaign-name             The name of campaign triggering the event.
- tag                       Message tag, if it was tagged. See :ref:`tagging`.
- mailing-list              The address of mailing list the original message was sent to.
- "custom variables"        Your own custom JSON object included in the header (see :ref:`manual-customdata`).
- timestamp                 Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
- token                     Randomly generated string with length 50 (see `securing webhooks`_).
- signature                 String with hexadecimal digits generate by HMAC algorithm
-                           (see `securing webhooks`_).
- attachment-x              attached file (‘x’ stands for number of the attachment). Attachments are
-                           included if the recipient ESP includes them in the bounce message. They are
-                           handled as file uploads, encoded as multipart/form-data.
- ======================    ===========================================================================
-
-.. _um-tracking-failures:
-
-Tracking Failures
-==================
-
-Mailgun tracks all delivery failures. Failures consist of both Hard Bounces (permanent failures) and Soft Bounces (temporary failures).
-
-You can see when failures happen in the ``Logs`` tab.  In addition, you can be notified through a webhook when a message is dropped (i.e., stop retries) or get the data programmatically through the :ref:`Events API <api-events>`.
-
-**Drop Event Webhook**
-
-In the ``Webhooks`` tab, you can specify a URL to be notified every time a message is dropped.
 There are a few reasons why Mailgun needs to stop attempting to deliver messages and drop them.
-The most common reason is that Mailgun received a Hard bounce or repeatedly received Soft bounces and continuing attempting to deliver may hurt your reputation with the receiving ESP.  Also, if the address is on one of the 'do not send lists' because that recipient
-had previously bounced, unsubscribed, or complained of spam, we will not attempt delivery and drop the message.  If one of
-these events occur we will POST the following parameters to your URL:
+The most common reason is that Mailgun received a Hard bounce or repeatedly received Soft bounces
+and continuing attempting to deliver may hurt your reputation with the receiving ESP.
+Also, if the address is on one of the 'do not send lists' because that recipient
+had previously bounced, unsubscribed, or complained of spam, we will not attempt delivery and drop the message.
+If one of these events occur we will POST the following `webhooks payload`_ to your ``permanent_fail`` URLs.
+You can specify webhook URLs programmaticaly using the :ref:`api-webhooks` API.
 
-.. container:: ptable
+**Temporary Failure Webhook**
 
- ==================    ==================================================================================
- Parameter Name        Description
- ==================    ==================================================================================
- event                 Event name ("dropped").
- recipient             Intended recipient.
- domain                Domain that sent the original message.
- message-headers       String list of all MIME headers of the original message dumped to a JSON string (order of headers preserved).
- reason                Reason for failure. Can be one either "hardfail" or "old". See below.
- code                  ESP response code, e.g. if the message was blocked as a spam (optional).
- description           Detailed explanation of why the messages was dropped
- "custom variables"    Your own custom JSON object included in the header (see :ref:`manual-customdata`).
- timestamp             Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
- token                 Randomly generated string with length 50 (see `securing webhooks`_).
- signature             String with hexadecimal digits generate by HMAC algorithm (see `securing webhooks`_).
- attachment-x          attached file (‘x’ stands for number of the attachment). Attachments are
-                       included if the recipient ESP includes them in the bounce message. They are
-                       handled as file uploads, encoded as multipart/form-data.
- ==================    ==================================================================================
-
-- ``old`` indicates that Mailgun tried to deliver the message unsuccessfully for more than 8 hours.
-- ``hardfail`` not delivering to an address that previously bounced, unsubscribed, or complained.
+If Mailgun got a Soft bounce (temporary failure) we will POST the following `webhooks payload`_ to your ``temporary_fail`` URLs.
+You can specify webhooks URLs programmaticaly using the :ref:`api-webhooks` API.
 
 
 .. _um-tracking-deliveries:
@@ -1252,26 +1109,10 @@ You can see when deliveries happen in the ``Logs`` tab.  In addition, you can be
 
 **Delivered Event Webhook**
 
-In the ``Webhooks`` tab, you can specify a URL to be notified every time a
-message is delivered. If the message is successfully delivered to the intended
-recipient, we will POST the following parameters to your URL:
-
-.. container:: ptable
-
- ==================    ==================================================================================
- Parameter Name        Description
- ==================    ==================================================================================
- event                 Event name ("delivered").
- recipient             Intended recipient.
- domain                Domain that sent the original message.
- message-headers       String list of all MIME headers dumped to a JSON string (order of headers preserved).
- Message-Id            String id of the original message delivered to the recipient.
- "custom variables"    Your own custom JSON object included in the header of the original message (see :ref:`manual-customdata`).
- timestamp             Number of seconds passed since January 1, 1970 (see `securing webhooks`_).
- token                 Randomly generated string with length 50 (see `securing webhooks`_).
- signature             String with hexadecimal digits generate by HMAC algorithm (see `securing webhooks`_).
- ==================    ==================================================================================
-
+You can specify a webhook URL programmaticaly using the :ref:`api-webhooks` API
+to be notified every time a message is delivered.
+If the message is successfully delivered to the intended recipient,
+we will POST the following `webhooks payload`_ to your ``delivered`` URLs
 
 .. _stats:
 


### PR DESCRIPTION
1. the events examples are refreshed
2. Webhooks(deprecated) is removed from the main left tree menu and available as a link from the top of the webhooks page
3. Webhooks section of the User Manual heavily reworked:
- all the legacy webhooks data formats are moved to the "webhooks(deprecated)" page
- the new webhook payload is described, a reference to the Events Structure section is added
- Tracking bounces and Tracking Failures sections are merged