### PR TITLE
Clean up node.js example.

### DIFF
--- a/source/samples/send-simple-message.rst
+++ b/source/samples/send-simple-message.rst
@@ -128,16 +128,15 @@
 
 .. code-block:: js
 
- var mailgun = require("mailgun-js");
- var api_key = 'YOUR_API_KEY';
+ var API_KEY = 'YOUR_API_KEY';
  var DOMAIN = 'YOUR_DOMAIN_NAME';
- var mailgun = require('mailgun-js')({apiKey: api_key, domain: DOMAIN});
+ var mailgun = require('mailgun-js')({apiKey: API_KEY, domain: DOMAIN});
 
  var data = {
    from: 'Excited User <me@samples.mailgun.org>',
-   to: 'bar@example.com, YOU@YOUR_DOMAIN_NAME',
+   to: 'foo@example.com, bar@example.com',
    subject: 'Hello',
-   text: 'Testing some Mailgun awesomness!'
+   text: 'Testing some Mailgun awesomeness!'
  };
 
  mailgun.messages().send(data, function (error, body) {


### PR DESCRIPTION
Remove extraneous var in node.js simple-send-message example, normalize other parameters.