### PR TITLE
Fix get-mailing-lists call for JS

### DIFF
--- a/source/samples/get-mailing-lists.rst
+++ b/source/samples/get-mailing-lists.rst
@@ -91,6 +91,6 @@
  var DOMAIN = 'YOUR_DOMAIN_NAME';
  var mailgun = require('mailgun-js')({ apiKey: "YOUR_API_KEY", domain: DOMAIN });
 
- mailgun.post('/lists/pages', function (error, body) {
+ mailgun.get('/lists/pages', function (error, body) {
    console.log(body);
  });


### PR DESCRIPTION
Should be `mailgun.get` as opposed to `mailgun.post`.