### PR TITLE
Fix documentation build errors and php block CSS.

### DIFF
--- a/source/_static/samples.js
+++ b/source/_static/samples.js
@@ -24,13 +24,13 @@ var samples = {
         return this._sections;
     },
 
-    hide: function () {
-        for (var i = 0; i < this.langs().length; i++) {
-            var id = this.langs()[i];
-            id = id.replace("lang_", "");
-            this.hideSamples(id);
-        }
-    },
+    // hide: function () {
+    //     for (var i = 0; i < this.langs().length; i++) {
+    //         var id = this.langs()[i];
+    //         id = id.replace("lang_", "");
+    //         this.hideSamples(id);
+    //     }
+    // },
 
     show: function () {
         this.change($.cookie('samples_code_language') || 'bash');

--- a/source/api-intro.rst
+++ b/source/api-intro.rst
@@ -23,7 +23,7 @@ examples that will function. You're welcome to copy/paste and run the script to 
 .. _RESTful: http://en.wikipedia.org/wiki/Representational_State_Transfer
 .. _JSON: http://en.wikipedia.org/wiki/Json objects
 
-.. index:: Base URL
+.. _base-url:
 
 Base URL
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -39,7 +39,7 @@ the domain you're interested in::
 
     https://api.mailgun.net/v3/mydomain.com
 
-.. index:: Authentication
+.. _authentication:
 
 Authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -71,7 +71,7 @@ box::
 
     'Thu, 13 Oct 2011 18:02:00 GMT'
 
-.. index:: Errors
+.. _errors:
 
 Errors
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -91,14 +91,14 @@ Mailgun returns standard HTTP response codes.
  500, 502, 503, 504 Server Errors - something is wrong on Mailgun's end
  ================== ==========================================================
 
-.. index:: Webhooks
+.. _webhooks:
 
 Webhooks
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Mailgun can also POST data to your application when events (opens, clicks, bounces, etc.) occur or when you use Routes.  You can read more about :ref:`webhooks` and :ref:`um-routes` in the :ref:`user-manual`.
 
-.. index:: Mailgun Regions
+.. _mailgun-regions:
 
 Mailgun Regions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -113,21 +113,21 @@ Using a single account and billing plan, you can choose to provision new sending
  Account Information, User Accounts, Billing Details (invoices/plan information), API Keys, Domain Names Domain Metadata (e.g. SMTP credentials), Messages, Event Logs, Suppressions, Mailing Lists, Tags, Statistics, Routes, IP Addresses
  ======================================================================================================= ==================================================================================================================================
 
-The endpoints you will use for sending/receiving/tracking messages in the EU are below:
+Below are the endpoints you will use for sending/receiving/tracking messages in the EU:
 
 .. container:: ptable
 
-=============================   ====================   ==================== 
-Service                         US Endpoint            EU Endpoint
-=============================   ====================   ==================== 
- REST API                       api.mailgun.net        api.eu.mailgun.net
- Outgoing SMTP Server           smtp.mailgun.org       smtp.eu.mailgun.org
- Inbound SMTP Server (Routes)   mxa.mailgun.org        mxa.eu.mailgun.org
- Inbound SMTP Server (Routes)   mxb.mailgun.org        mxb.eu.mailgun.org
- Open/Click Tracking Endpoint   mailgun.org            eu.mailgun.org 
-=============================   ====================   ====================
+ ============================= ==================== ====================
+ Service                       US Endpoint          EU Endpoint
+ ============================= ==================== ====================
+ REST API                      api.mailgun.net      api.eu.mailgun.net
+ Outgoing SMTP Server          smtp.mailgun.org     smtp.eu.mailgun.org
+ Inbound SMTP Server (Routes)  mxa.mailgun.org      mxa.eu.mailgun.org
+ Inbound SMTP Server (Routes)  mxb.mailgun.org      mxb.eu.mailgun.org
+ Open/Click Tracking Endpoint  mailgun.org          eu.mailgun.org
+ ============================= ==================== ====================
 
-.. index:: Postman Integration
+.. _postman-integration:
 
 Postman Integration
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -156,4 +156,3 @@ Read more about Mailgun and Postman on our blog_.
 
 .. _Click here: https://www.getpostman.com/
 .. _blog: https://www.mailgun.com/blog/together-at-last-postman-meets-mailgun
-

--- a/source/quickstart.rst
+++ b/source/quickstart.rst
@@ -1,3 +1,5 @@
+.. _quickstart:
+
 Quickstart Guide
 #####################
 

--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -65,6 +65,8 @@ There are some limitations if you have not given us your payment information:
 If you have given us your payment information, there is no limit on number of messages
 sent and/or received and data retention for Logs and the :ref:`Events API <api-events>` is at least 30 days.
 
+.. _verifying-your-domain:
+
 Verifying Your Domain
 =====================
 


### PR DESCRIPTION
1. Comment out hide function for code samples.
2. API Intro page
- add labels to remove build warnings
- fix table spacing to remove build warnings
3. Add label to Quickstart page for linking (and to remove build warnings)
4. Add label to Verifying Your Domain for linking (and to remove build warnings)

