### PR TITLE
fix recipient/recipients in documentation

### DIFF
--- a/source/api-sending.rst
+++ b/source/api-sending.rst
@@ -195,7 +195,7 @@ These are the parameters when the ``Accept`` header is set to ``message/rfc2822`
  ===========    ======    ============================================================================================================
  Parameter      Type      Description
  ===========    ======    ============================================================================================================
- recipient      string    recipient of the message.
+ recipients     string    recipient of the message.
  sender         string    sender of the message as reported by SMTP MAIL FROM.
  from           string    sender of the message as reported by ``From`` message header, for example "Bob <bob@example.com>".
  subject        string    subject string.


### PR DESCRIPTION
When using the `message/rfc2822` header, the response contains a `recipients` field and no `recipient`

This fixes the documentation to match but I'd like to note that this is an inconsistency between retrieving the message through the storage endpoint and retrieving the message through the notify webhook.