### PR TITLE
Remove mailgun-go NewMessage function public key parameter

### DIFF
--- a/source/samples/add-bounce.rst
+++ b/source/samples/add-bounce.rst
@@ -91,7 +91,7 @@
 .. code-block:: go
 
  func AddBounce(domain, apiKey) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.AddBounce("bob@example.com", "550", "Undeliverable message error")
  }
 

--- a/source/samples/add-complaint.rst
+++ b/source/samples/add-complaint.rst
@@ -91,7 +91,7 @@
 .. code-block:: go
 
  func CreateComplaint(domain, apiKey, emailAddress string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.CreateComplaint("bob@example.com")
  }
 

--- a/source/samples/add-domain.rst
+++ b/source/samples/add-domain.rst
@@ -97,8 +97,8 @@
 .. code-block:: go
 
  func AddDomain(domain, apiKey string) error {
-        mg := mailgun.NewMailgun(domain, apiKey, "")
-        return mg.CreateDomain("YOUR_NEW_DOMAIN_NAME", "supersecretpassword", mailgun.Tag, false)
+   mg := mailgun.NewMailgun(domain, apiKey)
+   return mg.CreateDomain("YOUR_NEW_DOMAIN_NAME", "supersecretpassword", mailgun.Tag, false)
  }
 
 .. code-block:: js

--- a/source/samples/add-list-member.rst
+++ b/source/samples/add-list-member.rst
@@ -118,7 +118,7 @@
 .. code-block:: go
 
  func AddListMember(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    memberJoe := mailgun.Member{
      Address:    "joe@example.com",
      Name:       "Joe Example",

--- a/source/samples/add-list-members.rst
+++ b/source/samples/add-list-members.rst
@@ -101,7 +101,7 @@
 .. code-block:: go
 
  func AddListMembers(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.CreateMemberList(nil, "LIST@YOUR_DOMAIN_NAME", []interface{}{
      mailgun.Member{
        Address:    "alice@example.com",

--- a/source/samples/add-unsubscribe-all.rst
+++ b/source/samples/add-unsubscribe-all.rst
@@ -98,7 +98,7 @@
 .. code-block:: go
 
  func CreateUnsubscription(domain, apiKey string) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.Unsubscribe("bob@example.com", "*")
  }
 

--- a/source/samples/add-unsubscribe-tag.rst
+++ b/source/samples/add-unsubscribe-tag.rst
@@ -98,7 +98,7 @@
 .. code-block:: go
 
  func CreateUnsubscriptionWithTag(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.Unsubscribe("bob@example.com", "tag1")
  }
 

--- a/source/samples/add-webhook-deprecated.rst
+++ b/source/samples/add-webhook-deprecated.rst
@@ -96,7 +96,7 @@
 .. code-block:: go
 
  func CreateWebhook(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.CreateWebhook("deliver", "http://www.example.com")
  }
 

--- a/source/samples/add-webhook.rst
+++ b/source/samples/add-webhook.rst
@@ -116,7 +116,7 @@
 .. code-block:: go
 
  func CreateWebhook(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.CreateWebhook("clicked", "https://your_domain.com/v1/clicked")
  }
 

--- a/source/samples/create-credentials.rst
+++ b/source/samples/create-credentials.rst
@@ -99,7 +99,7 @@
 .. code-block:: go
 
  func CreateCredential(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.CreateCredential("alice@YOUR_DOMAIN_NAME", "secret")
  }
 

--- a/source/samples/create-domain.rst
+++ b/source/samples/create-domain.rst
@@ -98,7 +98,7 @@
 .. code-block:: go
 
  func CreateDomain(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.CreateDomain("YOUR_DOMAIN_NAME", "supersecretpw", mailgun.Tag, false)
  }
 

--- a/source/samples/create-mailing-list.rst
+++ b/source/samples/create-mailing-list.rst
@@ -97,16 +97,16 @@
 
 .. code-block:: go
 
-  func CreateMailingList(domain, apiKey string) (mailgun.List, error) {
-    mg := mailgun.NewMailgun(domain, apiKey, "")
-    protoList := mailgun.List{
-      Address:     "LIST@YOUR_DOMAIN_NAME",
-      Name:        "dev",
-      Description: "Mailgun developers list.",
-      AccessLevel: mailgun.Members,
-    }
-    return mg.CreateList(protoList)
-  }
+ func CreateMailingList(domain, apiKey string) (mailgun.List, error) {
+   mg := mailgun.NewMailgun(domain, apiKey)
+   protoList := mailgun.List{
+     Address:     "LIST@YOUR_DOMAIN_NAME",
+     Name:        "dev",
+     Description: "Mailgun developers list.",
+     AccessLevel: mailgun.Members,
+   }
+   return mg.CreateList(protoList)
+ }
 
 .. code-block:: js
 

--- a/source/samples/create-route.rst
+++ b/source/samples/create-route.rst
@@ -115,7 +115,7 @@
 .. code-block:: go
 
  func CreateRoute(domain, apiKey string) (mailgun.Route, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.CreateRoute(mailgun.Route{
      Priority:    1,
      Description: "Sample Route",

--- a/source/samples/delete-credentials.rst
+++ b/source/samples/delete-credentials.rst
@@ -88,7 +88,7 @@
 .. code-block:: go
 
  func DeleteCredential(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.DeleteCredential("alice")
  }
 

--- a/source/samples/delete-domain.rst
+++ b/source/samples/delete-domain.rst
@@ -86,7 +86,7 @@
 .. code-block:: go
 
  func DeleteDomain(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.DeleteDomain("subdomain.example.com")
  }
 

--- a/source/samples/delete-tag.rst
+++ b/source/samples/delete-tag.rst
@@ -88,7 +88,7 @@
 .. code-block:: go
 
  func DeleteTag(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.DeleteTag("newsletter")
  }
 

--- a/source/samples/delete-webhook-deprecated.rst
+++ b/source/samples/delete-webhook-deprecated.rst
@@ -86,7 +86,7 @@
 .. code-block:: go
 
  func DeleteWebhook(t *testing.T) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.DeleteWebhook("deliver")
  }
 

--- a/source/samples/delete-webhook.rst
+++ b/source/samples/delete-webhook.rst
@@ -86,7 +86,7 @@
 .. code-block:: go
 
  func DeleteWebhook(t *testing.T) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.DeleteWebhook("clicked")
  }
 

--- a/source/samples/events-date-time-recipient.rst
+++ b/source/samples/events-date-time-recipient.rst
@@ -116,7 +116,7 @@
 .. code-block:: go
 
  func GetLog(domain, apiKey string) ([]mailgun.Event, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    ei := mg.NewEventIterator()
    err := ei.GetFirstPage(mailgun.GetEventsOptions{
      Begin:          time.Now().Add(-50 * Time.Minute),

--- a/source/samples/events-failure.rst
+++ b/source/samples/events-failure.rst
@@ -92,7 +92,7 @@
 .. code-block:: go
 
  func GetLog2(domain, apiKey string) ([]mailgun.Event, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    ei := mg.NewEventIterator()
    err := ei.GetFirstPage(mailgun.GetEventsOptions{
      Filter:         map[string]string{

--- a/source/samples/events-pagination.rst
+++ b/source/samples/events-pagination.rst
@@ -85,7 +85,7 @@
 .. code-block:: go
 
  func GetLog2(domain, apiKey string) ([]mailgun.Event, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    ei := mg.NewEventIterator()
    err := ei.GetFirstPage(mailgun.GetEventsOptions{
      Filter:         map[string]string{

--- a/source/samples/get-bounce.rst
+++ b/source/samples/get-bounce.rst
@@ -87,7 +87,7 @@
 .. code-block:: go
 
  func GetBounce(domain, apiKey string) (mailgun.Bounce, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.GetSingleBounce("foo@bar.com")
  }
 

--- a/source/samples/get-bounces.rst
+++ b/source/samples/get-bounces.rst
@@ -85,7 +85,7 @@
 .. code-block:: go
 
  func GetBounces(domain, apiKey string) (int, []mailgun.Bounce, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    total, bounces, err := mg.GetBounces(-1, -1)
    return total, bounces, err
  }

--- a/source/samples/get-complaint.rst
+++ b/source/samples/get-complaint.rst
@@ -87,7 +87,7 @@
 .. code-block:: go
 
  func GetComplaints(domain, apiKey string) (mailgun.Complaint, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.GetSingleComplaint("baz@example.com")
  }
 

--- a/source/samples/get-complaints.rst
+++ b/source/samples/get-complaints.rst
@@ -89,7 +89,7 @@
 .. code-block:: go
 
  func GetComplaints(domain, apiKey string) (int, []mailgun.Complaint, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.GetComplaints()
  }
 

--- a/source/samples/get-credentials.rst
+++ b/source/samples/get-credentials.rst
@@ -88,7 +88,7 @@
 .. code-block:: go
 
  func GetCredentials(domain, apiKey string) (int, []mailgun.Credential, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.GetCredentials(-1, -1)
  }
 

--- a/source/samples/get-domain.rst
+++ b/source/samples/get-domain.rst
@@ -88,7 +88,7 @@
 .. code-block:: go
 
  func GetSingleDomain(domain, apiKey string) (mailgun.Domain, []mailgun.DNSRecord, []mailgun.DNSRecord, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.GetSingleDomain(domains[0].Name)
  }
 

--- a/source/samples/get-domains.rst
+++ b/source/samples/get-domains.rst
@@ -95,7 +95,7 @@
 .. code-block:: go
 
  func GetDomains(domain, apiKey string) (int, []mailgun.Domain, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.GetDomains(-1, -1)
  }
 

--- a/source/samples/get-list-members.rst
+++ b/source/samples/get-list-members.rst
@@ -89,7 +89,7 @@
 .. code-block:: go
 
  func GetMembers(domain, apiKey string) (int, []mailgun.Member, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.GetMembers(-1, -1, mailgun.All, "LIST@YOUR_DOMAIN_NAME")
  }
 

--- a/source/samples/get-parse.rst
+++ b/source/samples/get-parse.rst
@@ -93,7 +93,7 @@
 .. code-block:: go
 
  func ParseAddress(domain, publicApiKey string) ([]string, []string, error) {
-   mg := mailgun.NewMailgun(domain, "", publicApiKey)
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.ParseAddress(
      "Alice <alice@example.com>",
      "bob@example.com",

--- a/source/samples/get-route.rst
+++ b/source/samples/get-route.rst
@@ -87,7 +87,7 @@
 .. code-block:: go
 
  func GetRouteByID(domain, apiKey string) (Route, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.GetRouteByID("4e97c1b2ba8a48567f007fb6")
  }
 

--- a/source/samples/get-routes.rst
+++ b/source/samples/get-routes.rst
@@ -94,7 +94,7 @@
 .. code-block:: go
 
  func GetRoutes(domain, apiKey string) (int, []mailgun.Route, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.GetRoutes(-1, -1)
  }
 

--- a/source/samples/get-stats.rst
+++ b/source/samples/get-stats.rst
@@ -109,7 +109,7 @@
 .. code-block:: go
 
  func GetStats(domain, apiKey string) ([]Stat, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    _, stats, err := mg.GetStats(-1, -1, nil, "accepted", "delivered", "failed");
    return stats, err
  }

--- a/source/samples/get-unsubscribes.rst
+++ b/source/samples/get-unsubscribes.rst
@@ -88,7 +88,7 @@
 .. code-block:: go
 
  func GetUnsubscribes(domain, apiKey string) (int, []mailgun.Unsubscribe, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.GetUnsubscribes(-1, -1)
  }
 

--- a/source/samples/get-validate.rst
+++ b/source/samples/get-validate.rst
@@ -93,7 +93,7 @@
 .. code-block:: go
 
  func ValidateEmail(domain, publicApiKey string) (mailgun.EmailVerification, error) {
-   mg := mailgun.NewMailgun(domain, "", publicApiKey)
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.ValidateEmail("foo@mailgun.net")
  }
 

--- a/source/samples/get-webhook-deprecated.rst
+++ b/source/samples/get-webhook-deprecated.rst
@@ -86,7 +86,7 @@
 .. code-block:: go
 
  func GetWebhook(domain, apiKey string) (string, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.GetWebhookByType("deliver")
  }
 

--- a/source/samples/get-webhook.rst
+++ b/source/samples/get-webhook.rst
@@ -86,7 +86,7 @@
 .. code-block:: go
 
  func GetWebhook(domain, apiKey string) (string, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.GetWebhookByType("clicked")
  }
 

--- a/source/samples/get-webhooks.rst
+++ b/source/samples/get-webhooks.rst
@@ -85,7 +85,7 @@
 .. code-block:: go
 
  func GetWebhooks(domain, apiKey string) (map[string]string, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.GetWebhooks()
  }
 

--- a/source/samples/remove-list-member.rst
+++ b/source/samples/remove-list-member.rst
@@ -92,7 +92,7 @@
 .. code-block:: go
 
  func DeleteListMember(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.DeleteMember("joe@example.com", "LIST@YOUR_DOMAIN_NAME")
  }
 

--- a/source/samples/remove-mailing-list.rst
+++ b/source/samples/remove-mailing-list.rst
@@ -87,7 +87,7 @@
 .. code-block:: go
 
  func DeleteList(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.DeleteList("LIST@YOUR_DOMAIN_NAME")
  }
 

--- a/source/samples/send-complex-message.rst
+++ b/source/samples/send-complex-message.rst
@@ -145,7 +145,7 @@
 .. code-block:: go
 
  func SendComplexMessage(domain, apiKey string) (string, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    m := mg.NewMessage(
      "Excited User <YOU@YOUR_DOMAIN_NAME>",
      "Hello",

--- a/source/samples/send-inline-image.rst
+++ b/source/samples/send-inline-image.rst
@@ -131,7 +131,7 @@
 .. code-block:: go
 
  func SendInlineImage(domain, apiKey string) (string, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    m := mg.NewMessage(
      "Excited User <YOU@YOUR_DOMAIN_NAME>",
      "Hello",

--- a/source/samples/send-message-no-tracking.rst
+++ b/source/samples/send-message-no-tracking.rst
@@ -120,7 +120,7 @@
 .. code-block:: go
 
  func SendMessageNoTracking(domain, apiKey string) (string, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    m := mg.NewMessage(
      "Excited User <YOU@YOUR_DOMAIN_NAME>",
      "Hello",

--- a/source/samples/send-mime-message.rst
+++ b/source/samples/send-mime-message.rst
@@ -107,7 +107,7 @@
 .. code-block:: go
 
  func SendMimeMessage(domain, apiKey string) (string, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    mimeMsgReader, err := os.Open("files/message.mime")
    if err != nil {
      return "", err

--- a/source/samples/send-scheduled-message.rst
+++ b/source/samples/send-scheduled-message.rst
@@ -120,7 +120,7 @@
 .. code-block:: go
 
  func SendScheduledMessage(domain, apiKey string) (string, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, publicApiKey)
+   mg := mailgun.NewMailgun(domain, apiKey)
    m := mg.NewMessage(
      "Excited User <YOU@YOUR_DOMAIN_NAME>",
      "Hello",

--- a/source/samples/send-simple-message.rst
+++ b/source/samples/send-simple-message.rst
@@ -115,7 +115,7 @@
 .. code-block:: go
 
  func SendSimpleMessage(domain, apiKey string) (string, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, publicApiKey)
+   mg := mailgun.NewMailgun(domain, apiKey)
    m := mg.NewMessage(
      "Excited User <mailgun@YOUR_DOMAIN_NAME>",
      "Hello",

--- a/source/samples/send-tagged-message.rst
+++ b/source/samples/send-tagged-message.rst
@@ -125,7 +125,7 @@
 .. code-block:: go
 
  func SendTaggedMessage(domain, apiKey string) (string, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    m := mg.NewMessage(
      "Excited User <YOU@YOUR_DOMAIN_NAME>",
      "Hello",

--- a/source/samples/send-template-message.rst
+++ b/source/samples/send-template-message.rst
@@ -135,7 +135,7 @@
  }
 
  func SendTemplateMessage(domain, apiKey string) (string, error) {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    m := mg.NewMessage(
      "Excited User <YOU@YOUR_DOMAIN_NAME>",
      "Hey %recipient.first%",

--- a/source/samples/update-list-member.rst
+++ b/source/samples/update-list-member.rst
@@ -105,7 +105,7 @@
 .. code-block:: go
 
  func UpdateMember(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    _, err = mg.UpdateMember("bar@example.com", "LIST@YOUR_DOMAIN_NAME", mailgun.Member{
      Name: "Foo Bar",
      Subscribed: mailgun.Unsubscribed,

--- a/source/samples/update-webhook-deprecated.rst
+++ b/source/samples/update-webhook-deprecated.rst
@@ -94,7 +94,7 @@
 .. code-block:: go
 
  func UpdateWebhook(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.UpdateWebhook("deliver", "http://api.example.com")
  }
 

--- a/source/samples/update-webhook.rst
+++ b/source/samples/update-webhook.rst
@@ -93,7 +93,7 @@
 .. code-block:: go
 
  func UpdateWebhook(domain, apiKey string) error {
-   mg := mailgun.NewMailgun(domain, apiKey, "")
+   mg := mailgun.NewMailgun(domain, apiKey)
    return mg.UpdateWebhook("clicked", "https://your_domain.com/clicked")
  }
 


### PR DESCRIPTION
[Issue 72](https://github.com/mailgun/mailgun-go/issues/72)

It looks like you have changed the public interface going from V1 to V2 in that the NewMailgun function no longer takes a public API key parameter. I have updated the Go code examples that have not been updated to reflect this. I don't see a separation of documentation for V1 and V2 and the website appears to state we are on V1 and the endpoint shows V3.