### PR TITLE
update parameters for /v2/domains POST

### DIFF
--- a/source/api-domains.rst
+++ b/source/api-domains.rst
@@ -78,6 +78,11 @@ Create a new domain. See examples below.
  dkim_key_size         Size of domain's DKIM key pairs: ``1024`` or ``2048``
 
 		       The default is ``1024``
+ ips                   An optional, comma-separated list of dedicated IP addresses 
+                       to be assigned to this domain. If not specified all dedicated
+                       IP addresses on the account will be assigned. If a requested
+                       IP doesn't belong to the account, or is on a warm-up plan,
+                       a `400` is returned.
  ===================== ========================================================
 
 .. code-block:: url


### PR DESCRIPTION
ips is a new, optional parameter when creating a new domain.