### PR TITLE
Use `field` instead of `queryString`

### DIFF
--- a/source/samples/resend-simple-message.rst
+++ b/source/samples/resend-simple-message.rst
@@ -20,7 +20,7 @@
 
          HttpResponse<JsonNode> request = Unirest.post("https://se.api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME + "/messages/{storage_url}")
              .basicAuth("api", API_KEY)
-             .queryString("to", "user@samples.mailgun.org")
+             .field("to", "user@samples.mailgun.org")
              .asJson();
 
      return request.getBody();

--- a/source/samples/send-complex-message.rst
+++ b/source/samples/send-complex-message.rst
@@ -30,13 +30,13 @@
 
          HttpResponse<JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/messages")
 	         .basicAuth("api", API_KEY)
-	      	 .queryString("from", "Excited User <USER@YOURDOMAIN.COM>")
-	      	 .queryString("to", "alice@example.com")
-	      	 .queryString("cc", "bob@example.com")
-	      	 .queryString("bcc", "joe@example.com")
-	      	 .queryString("subject", "Hello")
-	      	 .queryString("text", "Testing out some Mailgun awesomeness!")
-	      	 .queryString("html", "<html>HTML version </html>")
+	      	 .field("from", "Excited User <USER@YOURDOMAIN.COM>")
+	      	 .field("to", "alice@example.com")
+	      	 .field("cc", "bob@example.com")
+	      	 .field("bcc", "joe@example.com")
+	      	 .field("subject", "Hello")
+	      	 .field("text", "Testing out some Mailgun awesomeness!")
+	      	 .field("html", "<html>HTML version </html>")
 	      	 .field("attachment", new File("/temp/folder/test.txt"))
 	      	 .asJson();
 

--- a/source/samples/send-connection.rst
+++ b/source/samples/send-connection.rst
@@ -27,11 +27,11 @@
 
          HttpResponse<JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/messages")
 	         .basicAuth("api", API_KEY)
-	      	 .queryString("from", "Excited User <YOU@YOUR_DOMAIN_NAME>")
-             .queryString("to", "alice@example.com")
-             .queryString("to", "bob@example.com")
-             .queryString("subject", "Hello")
-             .queryString("text", "Testing out some Mailgun awesomeness!")
+	      	 .field("from", "Excited User <YOU@YOUR_DOMAIN_NAME>")
+             .field("to", "alice@example.com")
+             .field("to", "bob@example.com")
+             .field("subject", "Hello")
+             .field("text", "Testing out some Mailgun awesomeness!")
              .field("o:require-tls", "true")
              .field("o:skip-verification", "false")
              .asJson();

--- a/source/samples/send-inline-image.rst
+++ b/source/samples/send-inline-image.rst
@@ -27,12 +27,12 @@
 
          HttpResponse<JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/messages")
              .basicAuth("api", API_KEY)
-             .queryString("from", "Excited User <YOU@YOUR_DOMAIN_NAME>")
-             .queryString("to", "alice@example.com")
-             .queryString("to", "bob@example.com")
-	         .queryString("cc", "joe@example.com")
-             .queryString("subject", "Hello")
-             .queryString("text", "Testing out some Mailgun awesomeness!")
+             .field("from", "Excited User <YOU@YOUR_DOMAIN_NAME>")
+             .field("to", "alice@example.com")
+             .field("to", "bob@example.com")
+	         .field("cc", "joe@example.com")
+             .field("subject", "Hello")
+             .field("text", "Testing out some Mailgun awesomeness!")
 	         .field("html", "<html>Inline image here: <img src=\"cid:test.jpg\"></html>")
 	         .asJson();
 

--- a/source/samples/send-message-no-tracking.rst
+++ b/source/samples/send-message-no-tracking.rst
@@ -26,10 +26,10 @@
 
          HttpResponse<JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/messages")
             .basicAuth("api", API_KEY)
-            .queryString("from", "Excited User <YOU@YOUR_DOMAIN_NAME>")
- 			.queryString("to", "alice@example.com")
- 	        .queryString("subject", "Hello")
- 		    .queryString("text", "Testing some Mailgun awesomeness")
+            .field("from", "Excited User <YOU@YOUR_DOMAIN_NAME>")
+ 			.field("to", "alice@example.com")
+ 	        .field("subject", "Hello")
+ 		    .field("text", "Testing some Mailgun awesomeness")
  		    .field("o:tracking", "False")
  		    .asJson();
 

--- a/source/samples/send-mime-message.rst
+++ b/source/samples/send-mime-message.rst
@@ -24,9 +24,9 @@
          HttpResponse<JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/messages.mime")
   		     .basicAuth("api", API_KEY)
   			 .header("content-type", "multipart/form-data;")
-  			 .queryString("from", "Excited User <USER@YOURDOMAIN.COM>")
-  			 .queryString("to", "Megan@example.com")
-  			 .queryString("subject", "Bah-weep-graaaaagnah wheep nini bong.")
+  			 .field("from", "Excited User <USER@YOURDOMAIN.COM>")
+  			 .field("to", "Megan@example.com")
+  			 .field("subject", "Bah-weep-graaaaagnah wheep nini bong.")
   			 .field("message", new File("/temp/folder/file.mime"))
   			 .asJson();
 

--- a/source/samples/send-scheduled-message.rst
+++ b/source/samples/send-scheduled-message.rst
@@ -26,10 +26,10 @@
 
     	 HttpResponse<JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/messages")
    			 .basicAuth("api", API_KEY)
-   			 .queryString("from", "Excited User <USER@YOURDOMAIN.COM>")
-   			 .queryString("to", "bruce@example")
-   			 .queryString("subject", "Bah-weep-graaaaagnah wheep nini bong.")
-   			 .queryString("text", "Testing some MailGun awesomeness")
+   			 .field("from", "Excited User <USER@YOURDOMAIN.COM>")
+   			 .field("to", "bruce@example")
+   			 .field("subject", "Bah-weep-graaaaagnah wheep nini bong.")
+   			 .field("text", "Testing some MailGun awesomeness")
    			 .field("o:deliverytime", "Sat, 20 May 2017 2:50:00 -0000")
    			 .asJson();
 

--- a/source/samples/send-simple-message.rst
+++ b/source/samples/send-simple-message.rst
@@ -26,10 +26,10 @@
 
          HttpResponse<JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/messages")
 			 .basicAuth("api", API_KEY)
-		     .queryString("from", "Excited User <USER@YOURDOMAIN.COM>")
-		     .queryString("to", "artemis@example.com")
-		     .queryString("subject", "hello")
-		     .queryString("text", "testing")
+		     .field("from", "Excited User <USER@YOURDOMAIN.COM>")
+		     .field("to", "artemis@example.com")
+		     .field("subject", "hello")
+		     .field("text", "testing")
 		     .asJson();
 
 	    return request.getBody();

--- a/source/samples/send-tagged-message.rst
+++ b/source/samples/send-tagged-message.rst
@@ -27,10 +27,10 @@
 
          HttpResponse<JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/messages")
              .basicAuth("api", API_KEY)
-		     .queryString("from", "Excited User <YOU@YOUR_DOMAIN_NAME>")
-             .queryString("to", "alice@example")
-             .queryString("subject", "Hello.")
-             .queryString("text", "Testing some Mailgun awesomeness")
+		     .field("from", "Excited User <YOU@YOUR_DOMAIN_NAME>")
+             .field("to", "alice@example")
+             .field("subject", "Hello.")
+             .field("text", "Testing some Mailgun awesomeness")
              .field("o:tag", "newsletters")
              .field("o:tag", "September newsletter")
              .asJson();

--- a/source/samples/send-template-message.rst
+++ b/source/samples/send-template-message.rst
@@ -27,11 +27,11 @@
 
      	 HttpResponse<JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/messages")
      	 	 .basicAuth("api", API_KEY)
-     	 	 .queryString("from", "Excited User <YOU@YOUR_DOMAIN_NAME>")
-             .queryString("to", "alice@example.com")
-             .queryString("to", "bob@example.com")
-     	  	 .queryString("Subject", "Hello, %recipient.first%!")
-     	  	 .queryString("text", "If you wish to unsubscribe, click <https://mailgun.com/unsubscribe/%recipient.id%>")
+     	 	 .field("from", "Excited User <YOU@YOUR_DOMAIN_NAME>")
+             .field("to", "alice@example.com")
+             .field("to", "bob@example.com")
+     	  	 .field("Subject", "Hello, %recipient.first%!")
+     	  	 .field("text", "If you wish to unsubscribe, click <https://mailgun.com/unsubscribe/%recipient.id%>")
      	 	 .field("recipient-variables", "{\"bob@example.com\": {\"first\":\"Bob\", \"id\":1}, \"alice@example.com\": {\"first\":\"Alice\", \"id\": 2}}")
      		 .asJson();
 


### PR DESCRIPTION
All Java POST examples to use `field` to build request bodies as
`queryString` is incorrect for POSTs and will usually result in a `414`
response.