### PR TITLE
Improve Ruby Examples for email validation REST API calls

### DIFF
--- a/source/samples/get-parse.rst
+++ b/source/samples/get-parse.rst
@@ -51,12 +51,12 @@
 .. code-block:: rb
 
  def get_parse
-   url_params = {}
-   url_params[:addresses] = "Alice <alice@example.com>,bob@example.com"
-   query_string = url_params.collect {|k, v| "#{k.to_s}=#{CGI::escape(v.to_s)}"}.
-     join("&")
-   RestClient.get "https://api:pubkey-5ogiflzbnjrljiky49qxsiozqef5jxp7"\
-   "@api.mailgun.net/v3/address/parse?#{query_string}"
+   url_params = { addresses:  "Alice <alice@example.com>,bob@example.com" }
+   public_key = "pubkey-5ogiflzbnjrljiky49qxsiozqef5jxp7"
+   parse_url = "https://api:#{public_key}@api.mailgun.net/v3/address/parse"
+   RestClient::Request.execute method: :get, url: parse_url,
+                                       headers: { params: url_params },
+                                       user: 'api', password: public_key
  end
 
 .. code-block:: csharp

--- a/source/samples/get-validate.rst
+++ b/source/samples/get-validate.rst
@@ -52,12 +52,12 @@
 .. code-block:: rb
 
  def get_validate
-   url_params = {}
-   url_params[:address] = "foo@mailgun.net"
-   query_string = url_params.collect {|k, v| "#{k.to_s}=#{CGI::escape(v.to_s)}"}.
-     join("&")
-   RestClient.get "https://api:pubkey-5ogiflzbnjrljiky49qxsiozqef5jxp7"\
-   "@api.mailgun.net/v3/address/validate?#{query_string}"
+   url_params = { address: "foo@mailgun.net" }
+   public_key = "pubkey-5ogiflzbnjrljiky49qxsiozqef5jxp7"
+   validate_url = "https://api.mailgun.net/v3/address/validate"
+   RestClient::Request.execute method: :get, url: validate_url,
+                                       headers: { params: url_params },
+                                       user: 'api', password: public_key
  end
 
 .. code-block:: csharp

--- a/source/samples/get-validate4.rst
+++ b/source/samples/get-validate4.rst
@@ -52,12 +52,12 @@
 .. code-block:: rb
 
  def get_validate
-   url_params = {}
-   url_params[:address] = "foo@mailgun.net"
-   query_string = url_params.collect {|k, v| "#{k.to_s}=#{CGI::escape(v.to_s)}"}.
-     join("&")
-   RestClient.get "https://api:pubkey-5ogiflzbnjrljiky49qxsiozqef5jxp7"\
-   "@api.mailgun.net/v4/address/validate?#{query_string}"
+   url_params = { address: "foo@mailgun.net" }
+   public_key = "pubkey-5ogiflzbnjrljiky49qxsiozqef5jxp7"
+   validate_url = "https://api.mailgun.net/v4/address/validate"
+   RestClient::Request.execute method: :get, url: validate_url,
+                                       headers: { params: url_params },
+                                       user: 'api', password: public_key
  end
 
 .. code-block:: csharp


### PR DESCRIPTION
- use RestClient's GET built-in GET parameter serialisation
- use single line hash declaration