### PR TITLE
v4 validation uses private key not public key

### DIFF
--- a/source/samples/get-validate4.rst
+++ b/source/samples/get-validate4.rst
@@ -1,7 +1,7 @@
 
 .. code-block:: bash
 
-  curl -G --user 'api:pubkey-5ogiflzbnjrljiky49qxsiozqef5jxp7' -G \
+  curl -G --user 'api:PRIVATE_API_KEY' -G \
       https://api.mailgun.net/v4/address/validate \
       --data-urlencode address='foo@mailgun.net'
 
@@ -19,7 +19,7 @@
      public static JsonNode validateEmail() throws UnirestException {
  
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v4/address/validate")
-             .basicAuth("api", PUBLIC_API_KEY)
+             .basicAuth("api", PRIVATE_API_KEY)
              .queryString("address", "foo@mailgun.com")
              .asJson();
  
@@ -34,7 +34,7 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('pubkey-5ogiflzbnjrljiky49qxsiozqef5jxp7');
+  $mgClient = new Mailgun('PRIVATE_API_KEY');
   $validateAddress = 'foo@mailgun.net';
 
   # Issue the call to the client.
@@ -46,14 +46,14 @@
  def get_validate():
      return requests.get(
          "https://api.mailgun.net/v4/address/validate",
-         auth=("api", "pubkey-5ogiflzbnjrljiky49qxsiozqef5jxp7"),
+         auth=("api", "PRIVATE_API_KEY"),
          params={"address": "foo@mailgun.net"})
 
 .. code-block:: rb
 
  def get_validate
    url_params = { address: "foo@mailgun.net" }
-   public_key = "pubkey-5ogiflzbnjrljiky49qxsiozqef5jxp7"
+   public_key = "PRIVATE_API_KEY"
    validate_url = "https://api.mailgun.net/v4/address/validate"
    RestClient::Request.execute method: :get, url: validate_url,
                                        headers: { params: url_params },
@@ -81,7 +81,7 @@
          client.BaseUrl = new Uri ("https://api.mailgun.net/v4");
          client.Authenticator =
              new HttpBasicAuthenticator ("api",
-                                         "pubkey-5ogiflzbnjrljiky49qxsiozqef5jxp7");
+                                         "PRIVATE_API_KEY");
          RestRequest request = new RestRequest ();
          request.Resource = "/address/validate";
          request.AddParameter ("address", "foo@mailgun.net");
@@ -110,7 +110,7 @@
 .. code-block:: js
 
  var DOMAIN = 'YOUR_DOMAIN_NAME';
- var mailgun = require('mailgun-js')({ apiKey: "PUBLIC_API_KEY", domain: DOMAIN });
+ var mailgun = require('mailgun-js')({ apiKey: "PRIVATE_API_KEY", domain: DOMAIN });
 
  mailgun.validate('alice@example.com', function (error, body) {
    console.log(body);


### PR DESCRIPTION
The examples for v4 are showing pubkey and v4 currently doesn't support pubkey.  