### PR TITLE
Update Template bash example

### DIFF
--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -602,7 +602,7 @@ Another way to provide substitution variables is to use :ref:`X-Mailgun-Variable
   -F to='alice@example.com' \
   -F subject='Hello' \
   -F template='template.test' \
-  -H h:X-Mailgun-Variables='{"title": "API Documentation", "body": "Sending messages with template"}'
+  -F h:X-Mailgun-Variables='{"title": "API Documentation", "body": "Sending messages with template"}'
  
 The second way is preferable as it allows you to provide complex json data (arrays, nested json and so on)
 


### PR DESCRIPTION
`-H` in the example causes the X-Mailgun-Variables header to not be passed along within the API call and leaves any placeholders such as `{{name}}` as `{{name}}` in the final rendered result when sent to a recipient.

This could be misleading to customers testing sending with Templates