### PR TITLE
Update to log retention wording

### DIFF
--- a/source/api-events.rst
+++ b/source/api-events.rst
@@ -5,7 +5,7 @@ Events
 
 Mailgun tracks every event that happens to your emails and makes this data
 available to you through the Events API. Mailgun retains this detailed data for
-**two days** for free accounts and **30 days** for paid accounts. You can query
+**two days** for free accounts and up to **30 days** for paid accounts based on subscription plan. You can query
 the data and traverse through the result pages as explained below.
 
 .. code-block:: url


### PR DESCRIPTION
Different paid plan subscriptions have varying log retention. The current doc says 30 days for all paid plans. This update is to clarify log retention differs per plan.