### PR TITLE
Pluraise word

### DIFF
--- a/source/api-events.rst
+++ b/source/api-events.rst
@@ -287,7 +287,7 @@ event has. They are as follows:
  ================= ============================================================
 
 Events can change their structure as new features are added to Mailgun, but we
-only add new fields and never modify or remove existing one.
+only add new fields and never modify or remove existing ones.
 
 Below you can find sample events of various types:
 


### PR DESCRIPTION
The section on adding new fields seems to be missing an S when discussing
existing fields in the API; here we add it to try and correct that situation.