### PR TITLE
Update doc to remove unsupported param

### DIFF
--- a/source/api-email-validation.rst
+++ b/source/api-email-validation.rst
@@ -45,8 +45,6 @@ Given an arbitrary address, validates address based off defined checks.
  Parameter         	Description
  ====================== ========================================================
  address           	An email address to validate. (Maximum: 512 characters)
- api_key          	If you cannot use HTTP Basic Authentication (preferred),
-                   	you can pass your public api_key in as a parameter.
  ====================== ========================================================
 
 


### PR DESCRIPTION
`api_key` is an unsupported param in `v4` email validations and should be removed to prevent any confusion.