### PR TITLE
Spelling error

### DIFF
--- a/source/api-sending.rst
+++ b/source/api-sending.rst
@@ -43,7 +43,7 @@ This makes sense for parameters like ``cc``, ``to`` or ``attachment``.
  subject               Message subject
  text                  Body of the message. (text version)
  html                  Body of the message. (HTML version)
- amp-html              `AMP <https://developers.google.com/gmail/ampemail/>`_ part of the message. Please follow google `guidelines <https://developers.google.com/gmail/ampemail/>`_ to copmose and send AMP emails.
+ amp-html              `AMP <https://developers.google.com/gmail/ampemail/>`_ part of the message. Please follow google `guidelines <https://developers.google.com/gmail/ampemail/>`_ to compose and send AMP emails.
  attachment            File attachment. You can post multiple ``attachment``
                        values. **Important:** You must use ``multipart/form-data``
                        encoding when sending attachments.


### PR DESCRIPTION
Under AMP, updated "copmose" to "compose"