### PR TITLE
Add a Domain: PHP sample should use $domain

### DIFF
--- a/source/samples/add-domain.rst
+++ b/source/samples/add-domain.rst
@@ -36,11 +36,11 @@
 
   # Instantiate the client.
   $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_NEW_DOMAIN_NAME';
+  $domain = 'anothersample.mailgun.org';
 
   # Issue the call to the client.
   $result = $mgClient->post("domains", array(
-      'name'          => 'anothersample.mailgun.org',
+      'name'          => $domain,
       'smtp_password' => 'supersecretpassword'
   ));
 


### PR DESCRIPTION
Currently, `$domain` in the PHP sample for adding a domain is never used. The `name` key had a hard-coded value. Just updated for clarity.