### PR TITLE
Add node.js signature verification example to documentation

### DIFF
--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -1025,6 +1025,20 @@ And here's a sample in Go
         })
     }
 
+And here's a sample in Node.js
+
+.. code-block:: javascript
+
+    const crypto = require('crypto')
+
+    const verify = ({ apiKey, timestamp, token, signature }) => {
+        const encodedToken = crypto
+            .createHmac('sha256', apiKey)
+            .update(timestamp.concat(token))
+            .digest('hex')
+
+        return (encodedToken === signature)
+    }
 
 .. _manual-customdata:
 


### PR DESCRIPTION
Adds a node.js example to the "Securing Webhooks" section of the user manual