### PR TITLE
Fix python sample of hmac verification to be python3 compatible

### DIFF
--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -968,17 +968,17 @@ To verify the webhook is originating from Mailgun you need to:
 .. note:: Due to potentially large size of posted data, Mailgun computes an authentication
           signature based on a limited set of HTTP headers.
 
-Below is a Python code sample used to verify the signature:
+Below is a Python (version 3.x.x) code sample used to verify the signature:
 
 .. code-block:: python
 
     import hashlib, hmac
 
     def verify(api_key, token, timestamp, signature):
-        hmac_digest = hmac.new(key=api_key,
-                               msg='{}{}'.format(timestamp, token),
+        hmac_digest = hmac.new(key=api_key.encode(),
+                               msg=('{}{}'.format(timestamp, token)).encode(),
                                digestmod=hashlib.sha256).hexdigest()
-        return hmac.compare_digest(unicode(signature), unicode(hmac_digest))
+        return hmac.compare_digest(str(signature), str(hmac_digest))
 
 And here's a sample in Ruby:
 


### PR DESCRIPTION
In python3 as oppose to python2, there is no `unicode` function.
Moreover hmac expects bytes as input and not str- otherwise throws exception.
Tested and verified in python 3.7.2.