### PR TITLE
Update API examples in PHP

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -273,6 +273,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       {% include customsidebar %}
       {%- endif %}
       <div class="admonition note">You can find your API Key in your <a href="https://app.mailgun.com/app/dashboard" target="_blank">Control Panel</a></div>
+      <div class="admonition note">API and SMTP regions can be found at <a href="https://documentation.mailgun.com/en/latest/api-intro.html#mailgun-regions" target="_blank">Mailgun Regions</a></div>
     </div>
   </aside>
   {%- endif %}{% endif %}

--- a/source/samples/add-bounce.rst
+++ b/source/samples/add-bounce.rst
@@ -19,7 +19,7 @@
      public static JsonNode addBounce() throws UnirestException {
 
          HttpResponse <JsonNode> request =  Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/bounces")
-             .basicAuth("api", API_KEY)
+             .basicAuth("api", YOUR_API_KEY)
              .field("address", "bob@example.com")
              .asJson();
 
@@ -34,11 +34,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
+  $recipient = 'bob@example.com';
 
   # Issue the call to the client.
-  $result = $mgClient->post("$domain/bounces", array('address' => 'bob@example.com'));
+  $result = $mgClient->suppressions()->bounces()->create($domain, $recipient);
 
 .. code-block:: py
 

--- a/source/samples/add-complaint.rst
+++ b/source/samples/add-complaint.rst
@@ -30,11 +30,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
+  $recipient = 'bob@example.com';
 
   # Issue the call to the client.
-  $result = $mgClient->post("$domain/complaints", array('address' => 'bob@example.com'));
+  $result = $mgClient->suppressions()->complaints()->create($domain, $recipient);
 
 .. code-block:: py
 

--- a/source/samples/add-domain-ip.rst
+++ b/source/samples/add-domain-ip.rst
@@ -33,13 +33,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_NEW_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
+  $ip       = '127.0.0.1';
 
   # Issue the call to the client.
-  $result = $mgClient->post("$domain/ips", array(
-      'ip' => '127.0.0.1'
-  ));
+  $result = $mgClient->ips()->assign($domain, $ip);
 
 .. code-block:: py
 

--- a/source/samples/add-domain.rst
+++ b/source/samples/add-domain.rst
@@ -35,14 +35,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'anothersample.mailgun.org';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
-  $result = $mgClient->post("domains", array(
-      'name'          => $domain,
-      'smtp_password' => 'supersecretpassword'
-  ));
+  $result = $mgClient->domains()->create($domain);
 
 .. code-block:: py
 

--- a/source/samples/add-list-member.rst
+++ b/source/samples/add-list-member.rst
@@ -41,17 +41,18 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $mailing_list = 'LIST@YOUR_DOMAIN_NAME';
+  $address ='bob@example.com';
+  $name = 'Bob';
+  $vars = array("id" => "123456");
 
   # Issue the call to the client.
-  $result = $mgClient->post("lists/$listAddress/members", array(
-      'address'     => 'bar@example.com',
-      'name'        => 'Bob Bar',
-      'description' => 'Developer',
-      'subscribed'  => true,
-      'vars'        => '{"age": 26}'
-  ));
+  $result = $mgClient->mailingList()->member()->create(
+                                                    $mailing_list,
+                                                    $address,
+                                                    $name,
+                                                    $vars);
 
 .. code-block:: py
 

--- a/source/samples/add-list-members.rst
+++ b/source/samples/add-list-members.rst
@@ -36,14 +36,18 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $mailing_list = 'LIST@YOUR_DOMAIN_NAME';
+  $members = array(
+      array(
+          'address'   => 'bob@example.com',
+          'name'      => 'Bob',
+          'vars'      => array("id" => "123456")
+      )
+  );
 
   # Issue the call to the client.
-  $result = $mgClient->post("lists/$listAddress/members.json", array(
-      'members'    => '[{"address": "Alice <alice@example.com>", "vars": {"age": 26}}, {"name": "Alice", "address": "alice@example.com", "vars": {"age": 34}}]',
-      'upsert' => true
-  ));
+  $result = $mgClient->mailingList()->member()->createMultiple($mailing_list, $members);
 
 .. code-block:: py
 

--- a/source/samples/add-unsubscribe-all.rst
+++ b/source/samples/add-unsubscribe-all.rst
@@ -36,14 +36,13 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient  = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain    = 'YOUR_DOMAIN_NAME';
+  $recipient = 'bob@example.com';
+  $tag       = '*';
 
   # Issue the call to the client.
-  $result = $mgClient->post("$domain/unsubscribes", array(
-      'address' => 'bob@example.com',
-      'tag'     => '*'
-  ));
+  $result = $mgClient->suppressions()->unsubscribes()->create($domain, $recipient, $tag);
 
 .. code-block:: py
 

--- a/source/samples/add-unsubscribe-tag.rst
+++ b/source/samples/add-unsubscribe-tag.rst
@@ -12,19 +12,19 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode addUnsubscribe() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/unsubscribes")
              .basicAuth("api", API_KEY)
              .field("address", "bob@example.com")
              .field("tag", "tag1")
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -36,14 +36,13 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient  = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain    = 'YOUR_DOMAIN_NAME';
+  $recipient = 'bob@example.com';
+  $tag       = 'my_tag';
 
   # Issue the call to the client.
-  $result = $mgClient->post("$domain/unsubscribes", array(
-      'address' => 'bob@example.com',
-      'tag'     => 'myexampletag'
-  ));
+  $result = $mgClient->suppressions()->unsubscribes()->create($domain, $recipient, $tag);
 
 .. code-block:: py
 

--- a/source/samples/add-webhook-deprecated.rst
+++ b/source/samples/add-webhook-deprecated.rst
@@ -11,19 +11,19 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode addWebhook() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.post("https://api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME + "/webhooks")
              .basicAuth("api", API_KEY)
              .field("id","click")
              .field("url", "http://bin.example.com/8de4a9c4")
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -35,14 +35,13 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
+  $webhook  = 'delivered';
+  $destination_url = 'https://my.webhook.url/delivered'
 
   # Issue the call to the client.
-  $result = $mgClient->post("domains/$domain/webhooks", array(
-      'id'  => 'click',
-      'url' => 'http://bin.example.com/8de4a9c4'
-  ));
+  $result = $mgClient->webhooks()->create($domain, $webhook, $destination_url);
 
 .. code-block:: py
 

--- a/source/samples/add-webhook.rst
+++ b/source/samples/add-webhook.rst
@@ -13,13 +13,13 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode addWebhook() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.post("https://api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME + "/webhooks")
              .basicAuth("api", API_KEY)
              .field("id","click")
@@ -27,7 +27,7 @@
              .field("url", "https://your_domain.com/v2/clicked")
              .field("url", "https://your_partner_domain.com/v1/clicked")
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -39,18 +39,13 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
+  $webhook  = 'delivered';
+  $destination_url = 'https://my.webhook.url/delivered'
 
   # Issue the call to the client.
-  $result = $mgClient->post("domains/$domain/webhooks", array(
-      'id'  => 'clicked',
-      'url' => array(
-          'https://your_domain.com/v1/clicked',
-          'https://your_domain.com/v2/clicked',
-          'https://your_partner_domain.com/v1/clicked'
-      )
-  ));
+  $result = $mgClient->webhooks()->create($domain, $webhook, $destination_url);
 
 .. code-block:: py
 
@@ -59,7 +54,7 @@
          "https://api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/webhooks",
          auth=("api", "YOUR_API_KEY"),
          data={
-           'id':'clicked', 
+           'id':'clicked',
            'url':[ 'https://your_domain.com/v1/clicked',
            'https://your_domain.com/v2/clicked',
            'https://your_partner_domain.com/v1/clicked'

--- a/source/samples/add-whitelist.rst
+++ b/source/samples/add-whitelist.rst
@@ -29,16 +29,26 @@
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support Suppression Whiteslist endpoint.
+  # Consider using the following php curl function.
+  function add_domain_whitelist() {
+    $ch = curl_init();
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
-  # Issue the call to the client.
-  $result = $mgClient->post("$domain/whitelists", array('domain' => 'example.com'));
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/whitelists');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, array(
+        'address'=> 'bob@example.com')
+    );
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/change-pwd-credentials.rst
+++ b/source/samples/change-pwd-credentials.rst
@@ -11,18 +11,18 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode updatePassword() throws UnirestException {
- 
+
          HttpResponse<JsonNode> jsonResponse = Unirest.put("https://api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/credentials/alice")
              .basicAuth("api", API_KEY)
              .field("password", "supersecret")
              .asJson();
- 
+
          return jsonResponse.getBody();
      }
  }
@@ -34,14 +34,13 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $login= 'alice';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
+  $smtpUser = 'bob';
+  $smtpPass = 'new_password';
 
   # Issue the call to the client.
-  $result = $mgClient->put("domains/$domain/credentials/$login", array(
-      'password' => 'supersecret'
-  ));
+  $result = $mgClient->domains()->updateCredential($domain, $smtpUser, $smtpPass);
 
 .. code-block:: py
 

--- a/source/samples/create-bulk-validation.rst
+++ b/source/samples/create-bulk-validation.rst
@@ -26,6 +26,29 @@
      }
  }
 
+.. code-block:: php
+
+  # Currently, the PHP SDK does not support the v4 Validations endpoint.
+  # Consider using the following php curl function.
+  function upload_bulk_validation() {
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v4/address/validate/bulk/LIST_NAME');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, array(
+        'file'=> curl_file_create('subscribers.csv'))
+    );
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
+
 .. code-block:: py
 
  def validate_mailing_list():

--- a/source/samples/create-credentials.rst
+++ b/source/samples/create-credentials.rst
@@ -12,19 +12,19 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode createCredentials() throws UnirestException {
- 
+
          HttpResponse<JsonNode> jsonResponse = Unirest.post("https://api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME +"/credentials")
              .basicAuth("api", API_KEY)
              .field("login", "alice@YOUR_DOMAIN_NAME.com")
              .field("password", "supersecretpassword")
              .asJson();
- 
+
          return jsonResponse.getBody();
      }
  }
@@ -36,14 +36,13 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
+  $smtpUser = 'bob';
+  $smtpPass = 'new_password';
 
   # Issue the call to the client.
-  $result = $mgClient->post("domains/$domain/credentials", array(
-      'login'    => 'alice@YOUR_DOMAIN_NAME',
-      'password' => 'secret'
-  ));
+  $result = $mgClient->domains()->createCredential($domain, $smtpUser, $smtpPass);
 
 .. code-block:: py
 

--- a/source/samples/create-domain.rst
+++ b/source/samples/create-domain.rst
@@ -12,19 +12,19 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode addDomain() throws UnirestException {
- 
+
          HttpResponse<JsonNode> jsonResponse = Unirest.post("https://api.mailgun.net/v3/domains")
              .basicAuth("api", API_KEY)
              .field("name", "YOUR_NEW_DOMAIN_NAME")
              .field("smtp_password", "supersecretpassword")
              .asJson();
- 
+
          return jsonResponse.getBody();
      }
  }
@@ -36,13 +36,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
-  $result = $mgClient->post("domains", array(
-      'name'          => 'newdomain.mailgun.org',
-      'smtp_password' => 'supersecret'
-  ));
+  $result = $mgClient->domains()->create($domain);
 
 .. code-block:: py
 

--- a/source/samples/create-list-validation.rst
+++ b/source/samples/create-list-validation.rst
@@ -26,16 +26,23 @@
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support Mailing List validations.
+  # Consider using the following php curl function.
+  function upload_bulk_validation() {
+    $ch = curl_init();
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
-  # Issue the call to the client.
-  $result = $mgClient->post("lists/$listAddress/validate");
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/lists/LIST@YOUR_DOMAIN_NAME/validate');
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/create-mailing-list.rst
+++ b/source/samples/create-mailing-list.rst
@@ -12,19 +12,19 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode createMailingList() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.post("https://api.mailgun.net/v3/lists")
              .basicAuth("api", API_KEY)
              .field("address", "LIST@YOUR_DOMAIN_NAME")
              .field("description", "LIST_DESCRIPTION")
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -36,13 +36,14 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $mailing_list     = 'LIST@YOUR_DOMAIN_NAME';
+  $list_name        = 'Mailgun Subscribers';
+  $list_description = 'News and service updates';
+  $access_level     = 'readonly';
 
   # Issue the call to the client.
-  $result = $mgClient->post("lists", array(
-      'address'     => 'LIST@YOUR_DOMAIN_NAME',
-      'description' => 'Mailgun Dev List'
-  ));
+  $result = $mgClient->mailingList()->create($mailing_list, $list_name, $list_description, $access_level);
 
 .. code-block:: py
 

--- a/source/samples/create-route.rst
+++ b/source/samples/create-route.rst
@@ -14,13 +14,13 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode createRoute() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.post("https://api.mailgun.net/v3/routes")
              .basicAuth("api", API_KEY)
              .field("priority", "0")
@@ -29,7 +29,7 @@
              .field("action", "forward('http://myhost.com/messages/')")
              .field("action", "stop()")
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -41,15 +41,15 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+
+  # Define your expression, actions, and description
+  $expression   = 'match_recipient(".*@mg.example.com")';
+  $actions      = array('forward("my_address@example.com")', 'stop()');
+  $description  = 'Catch All and Forward';
 
   # Issue the call to the client.
-  $result = $mgClient->post("routes", array(
-      'priority'    => 0,
-      'expression'  => 'match_recipient(".*@YOUR_DOMAIN_NAME")',
-      'action'      => array('forward("http://host.com/messages")', 'stop()'),
-      'description' => 'Sample route'
-  ));
+  $result = $mgClient->routes()->create($expression, $actions, $description);
 
 .. code-block:: py
 

--- a/source/samples/delete-bulk-validation.rst
+++ b/source/samples/delete-bulk-validation.rst
@@ -10,20 +10,39 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode cancelMailingListValidation() throws UnirestException {
          url = "https://api.mailgun.net/v4/address/validate/bulk/LIST_NAME"
          HttpResponse <JsonNode> request = Unirest.delete(url)
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
+
+.. code-block:: php
+
+  # Currently, the PHP SDK does not support the v4 Validations endpoint.
+  # Consider using the following php curl function.
+  function delete_bulk_validation() {
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v4/address/validate/bulk/LIST_NAME');
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/delete-credentials.rst
+++ b/source/samples/delete-credentials.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode deleteCredentials() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.delete("https://api.mailgun.net/v3/domains/"+ YOUR_DOMAIN_NAME +"/credentials/user")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,12 +32,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $login = 'alice';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
+  $smtpUser = 'bob';
 
   # Issue the call to the client.
-  $result = $mgClient->delete("domains/$domain/credentials/$login");
+  $result = $mgClient->domains()->deleteCredential($domain, $smtpUser);
 
 .. code-block:: py
 

--- a/source/samples/delete-domain.rst
+++ b/source/samples/delete-domain.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode deleteDomain() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.delete("https://api.mailgun.net/v3/domains/domain.example.com")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,11 +32,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'example.mailgun.org';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
-  $result = $mgClient->delete("domains/$domain");
+  $result = $mgClient->domains()->delete($domain);
 
 .. code-block:: py
 

--- a/source/samples/delete-list-validation.rst
+++ b/source/samples/delete-list-validation.rst
@@ -10,33 +10,40 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode cancelMailingListValidation() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.delete("https://api.mailgun.net/v3/lists/YoungJustice@example.com/validate")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support Mailing List validations.
+  # Consider using the following php curl function.
+  function delete_mailing_list_validation() {
+    $ch = curl_init();
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
-  # Issue the call to the client.
-  $result = $mgClient->delete("lists/$listAddress/validate");
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/lists/LIST@YOUR_DOMAIN_NAME/validate');
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/delete-tag.rst
+++ b/source/samples/delete-tag.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode deleteTag() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.delete("https://api.mailgun.net/v3/"+ YOUR_DOMAIN_NAME + "/tags/newsletter")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,12 +32,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
   $domain = 'YOUR_DOMAIN_NAME';
-  $tag = 'myexampletag';
+  $tag    = 'my_tag';
 
   # Issue the call to the client.
-  $result = $mgClient->delete("$domain/tags/$tag");
+  $result = $mgClient->tags()->delete($domain, $tag);
 
 .. code-block:: py
 

--- a/source/samples/delete-webhook-deprecated.rst
+++ b/source/samples/delete-webhook-deprecated.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode deleteWebhook() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.delete("https://api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME + "/webhooks/click")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,11 +32,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
+  $webhook  = 'delivered';
 
   # Issue the call to the client.
-  $result = $mgClient->delete("$domain/webhooks/click");
+  $result = $mgClient->webhooks()->delete($domain, $webhook);
 
 .. code-block:: py
 

--- a/source/samples/delete-webhook.rst
+++ b/source/samples/delete-webhook.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode deleteWebhook() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.delete("https://api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME + "/webhooks/clicked")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,11 +32,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
+  $webhook  = 'delivered';
 
   # Issue the call to the client.
-  $result = $mgClient->delete("$domain/webhooks/clicked");
+  $result = $mgClient->webhooks()->delete($domain, $webhook);
 
 .. code-block:: py
 

--- a/source/samples/events-date-time-recipient.rst
+++ b/source/samples/events-date-time-recipient.rst
@@ -14,20 +14,20 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getLogs() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/events")
              .basicAuth("api", API_KEY)
              .queryString("begin", "Thurs, 18 May 2017 09:00:00 -0000")
              .queryString("ascending", "yes")
              .queryString("limit", 1)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -39,18 +39,18 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient    = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain      = 'YOUR_DOMAIN_NAME';
   $queryString = array(
-      'begin'        => 'Fri, 3 May 2013 09:00:00 -0000',
+      'begin'        => 'Wed, 1 Jan 2020 09:00:00 -0000',
       'ascending'    => 'yes',
       'limit'        =>  25,
       'pretty'       => 'yes',
-      'subject'      => 'test'
+      'recipient'    => 'bob@example.com'
   );
 
-  # Make the call to the client.
-  $result = $mgClient->get("$domain/events", $queryString);
+  # Issue the call to the client.
+  $result = $mgClient->events()->get($domain, $queryString);
 
 .. code-block:: py
 

--- a/source/samples/events-failure.rst
+++ b/source/samples/events-failure.rst
@@ -10,18 +10,18 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getLogs() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/events")
              .basicAuth("api", API_KEY)
              .queryString("event", "failed")
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -33,12 +33,18 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $queryString = array('event' => 'rejected OR failed');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain      = 'YOUR_DOMAIN_NAME';
+  $queryString = array(
+      'begin'        => 'Wed, 1 Jan 2020 09:00:00 -0000',
+      'ascending'    => 'yes',
+      'limit'        =>  25,
+      'pretty'       => 'yes',
+      'event'        => 'failed'
+  );
 
-  # Make the call to the client.
-  $result = $mgClient->get("$domain/events", $queryString);
+  # Issue the call to the client.
+  $result = $mgClient->events()->get($domain, $queryString);
 
 .. code-block:: py
 

--- a/source/samples/events-pagination.rst
+++ b/source/samples/events-pagination.rst
@@ -9,17 +9,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getLogsPagination() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/events/W3siYSI6IGZhbHNlLCAi")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -31,12 +31,20 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $nextPage = 'W3siYSI6IGZhbHNlLC';
+  $mgClient    = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain      = 'YOUR_DOMAIN_NAME';
+  $queryString = array(
+      'begin'        => 'Wed, 1 Jan 2020 09:00:00 -0000',
+      'ascending'    => 'yes',
+      'limit'        =>  25,
+      'pretty'       => 'yes'
+  );
 
-  # Make the call to the client.
-  $result = $mgClient->get("$domain/events/$nextPage");
+  # Issue the call to the client.
+  $result = $mgClient->events()->get($domain, $queryString);
+
+  # Request the next page.
+  $nextPage = $mgClient->events()->nextPage($result);
 
 .. code-block:: py
 

--- a/source/samples/events-traversal.rst
+++ b/source/samples/events-traversal.rst
@@ -9,17 +9,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getLogs() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/events")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -31,11 +31,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
 
-  # Make the call to the client.
-  $result = $mgClient->get("$domain/events");
+  # Issue the call to the client.
+  $result = $mgClient->events()->($domain);
 
 .. code-block:: py
 

--- a/source/samples/get-bounce.rst
+++ b/source/samples/get-bounce.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getSingleBounce() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/bounces/foo@bar.com")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,12 +32,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $bounce = 'bob@example.com';
+  $mgClient  = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain    = 'YOUR_DOMAIN_NAME';
+  $recipient = 'bob@example.com';
 
   # Issue the call to the client.
-  $result = $mgClient->get("$domain/bounces/$bounce");
+  $result = $mgClient->suppressions()->bounces()->show($domain, $recipient);
 
 .. code-block:: py
 

--- a/source/samples/get-bounces.rst
+++ b/source/samples/get-bounces.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getBounces() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/bounces")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,11 +32,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
-  $result = $mgClient->get("$domain/bounces");
+  $result = $mgClient->suppressions()->bounces()->index($domain);
 
 .. code-block:: py
 

--- a/source/samples/get-bulk-validation.rst
+++ b/source/samples/get-bulk-validation.rst
@@ -10,20 +10,39 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getMailingListValidation() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.get("https://api.mailgun.net/v4/address/validate/bulk/{list}")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
+
+.. code-block:: php
+
+  # Currently, the PHP SDK does not support the v4 Validations endpoint.
+  # Consider using the following php curl function.
+  function get_bulk_validation() {
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v4/address/validate/bulk/LIST_NAME');
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/get-bulk-validations.rst
+++ b/source/samples/get-bulk-validations.rst
@@ -10,20 +10,39 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getMailingListValidation() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.get("https://api.mailgun.net/v4/address/validate/bulk")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
+
+.. code-block:: php
+
+  # Currently, the PHP SDK does not support the v4 Validations endpoint.
+  # Consider using the following php curl function.
+  function get_bulk_validations() {
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v4/address/validate/bulk');
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/get-complaint.rst
+++ b/source/samples/get-complaint.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getComplaint() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/complaints/baz@example.com")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,12 +32,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $complaint = 'user@example.com';
+  $mgClient  = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain    = 'YOUR_DOMAIN_NAME';
+  $recipient = 'bob@example.com';
 
   # Issue the call to the client.
-  $result = $mgClient->get("$domain/complaints/$complaint");
+  $result = $mgClient->suppressions()->complaints()->show($domain, $recipient);
 
 .. code-block:: py
 

--- a/source/samples/get-complaints.rst
+++ b/source/samples/get-complaints.rst
@@ -10,37 +10,35 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getComplaints() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/complaints")
              .basicAuth("api", API_KEY)
              .queryString("limit", "100")
              .asJson();
- 
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
+
   # Include the Autoloader (see "Libraries" for install instructions)
   require 'vendor/autoload.php';
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient  = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain    = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
-  $result = $mgClient->get("$domain/complaints", array(
-      'limit' => 10,
-      'skip'  => 5
-  ));
+  $result = $mgClient->suppressions()->complaints()->index($domain);
 
 .. code-block:: py
 

--- a/source/samples/get-connection.rst
+++ b/source/samples/get-connection.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getConnections() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.get("https://api.mailgun.net/v3/domains/"+ YOUR_DOMAIN_NAME +"/connection")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,11 +32,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain = "YOUR_DOMAIN_NAME";
 
   # Issue the call to the client.
-  $result = $mgClient->get("domains/$domain/connection", array());
+  $result = $mgClient->domains()->connection($domain);
 
 .. code-block:: py
 

--- a/source/samples/get-credentials.rst
+++ b/source/samples/get-credentials.rst
@@ -32,14 +32,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain = "YOUR_DOMAIN_NAME";
 
   # Issue the call to the client.
-  $result = $mgClient->get("domains/$domain/credentials", array(
-      'limit' => 5,
-      'skip'  => 10
-  ));
+  $result = $mgClient->domains()->credentials($domain);
 
 .. code-block:: py
 

--- a/source/samples/get-domain-ips.rst
+++ b/source/samples/get-domain-ips.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getDomainIPs() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.get("https://api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME + "/ips")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,11 +32,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain = "YOUR_DOMAIN_NAME";
 
   # Issue the call to the client.
-  $result = $mgClient->get("domains/$domain/ips");
+  $result = $mgClient->ips()->domainIndex($domain);
 
 .. code-block:: py
 

--- a/source/samples/get-domain-tracking.rst
+++ b/source/samples/get-domain-tracking.rst
@@ -10,33 +10,40 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getDomainTracking() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.get("https://api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME + "/tracking")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support Mailing List validations.
+  # Consider using the following php curl function.
+  function get_domain_tracking_settings() {
+    $ch = curl_init();
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
-  # Issue the call to the client.
-  $result = $mgClient->get("domains/$domain/tracking");
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/tracking');
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/get-domain.rst
+++ b/source/samples/get-domain.rst
@@ -10,19 +10,19 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getDomain() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.get("https://api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME)
              .basicAuth("api", API_KEY)
              .queryString("skip", 0)
              .queryString("limit", 3)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -34,11 +34,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain = "YOUR_DOMAIN_NAME";
 
   # Issue the call to the client.
-  $result = $mgClient->get("domains/$domain");
+  $result = $mgClient->domains()->show($domain);
 
 .. code-block:: py
 

--- a/source/samples/get-domains.rst
+++ b/source/samples/get-domains.rst
@@ -12,20 +12,20 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
- 
+
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getDomains() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/domains")
              .basicAuth("api", API_KEY)
              .queryString("skip", 0)
              .queryString("limit", 3)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -37,10 +37,10 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
 
   # Issue the call to the client.
-  $result = $mgClient->get("domains", array('limit' => 5, 'skip' => 10));
+  $result = $mgClient->domains()->index();
 
 .. code-block:: py
 

--- a/source/samples/get-ip.rst
+++ b/source/samples/get-ip.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getIP() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.get("https://api.mailgun.net/v3/ips/127.0.0.1")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,11 +32,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $ip = '127.0.0.1';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $ip       = '127.0.0.1';
 
   # Issue the call to the client.
-  $result = $mgClient->get("ips/$ip");
+  $result = $mgClient->ips()->show($ip);
 
 .. code-block:: py
 

--- a/source/samples/get-ips.rst
+++ b/source/samples/get-ips.rst
@@ -34,12 +34,10 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
 
   # Issue the call to the client.
-  $result = $mgClient->get("ips", array(
-    'dedicated' => "true"
-  ));
+  $result = $mgClient->ips->index();
 
 .. code-block:: py
 

--- a/source/samples/get-limits.rst
+++ b/source/samples/get-limits.rst
@@ -26,16 +26,23 @@
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support Domain Tag limits.
+  # Consider using the following php curl function.
+  function get_domain_tag_limit() {
+    $ch = curl_init();
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
-  # Issue the call to the client.
-  $result = $mgClient->get("domains/$domain/limits/tag");
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/limits/tag');
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/get-list-members.rst
+++ b/source/samples/get-list-members.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode listMembers() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/lists/{list_name}@{domain}/members/pages")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,14 +32,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
+  $mgClient     = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $mailing_list = 'LIST@YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
-  $result = $mgClient->get("lists/$listAddress/members/pages", array(
-      'subscribed' => 'yes',
-      'limit'      =>  5
-  ));
+  $result =  $mgClient->mailingList()->member()->index($mailing_list);
 
 .. code-block:: py
 

--- a/source/samples/get-list-validation.rst
+++ b/source/samples/get-list-validation.rst
@@ -10,33 +10,40 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getMailingListValidation() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.post("https://api.mailgun.net/v3/lists/{list}@{domain}/validate")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support Mailing List Validations.
+  # Consider using the following php curl function.
+  function get_mailing_list_validation() {
+    $ch = curl_init();
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
-  # Issue the call to the client.
-  $result = $mgClient->get("lists/$listAddress/validate");
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/lists/LIST@YOUR_DOMAIN_NAME/validate');
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/get-mailing-lists.rst
+++ b/source/samples/get-mailing-lists.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
       // ...
- 
+
       public static JsonNode mailingLists() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/lists/pages")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,12 +32,10 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
 
   # Issue the call to the client.
-  $result = $mgClient->get("lists/pages", array(
-      'limit'      =>  5
-  ));
+  $response = $mgClient->mailingList()->pages();
 
 .. code-block:: py
 

--- a/source/samples/get-parse.rst
+++ b/source/samples/get-parse.rst
@@ -11,18 +11,18 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode parseAddresses() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/address/parse")
              .basicAuth("api", API_KEY)
              .queryString("addresses", "bob@example.com, alice@example.com")
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -34,11 +34,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('pubkey-5ogiflzbnjrljiky49qxsiozqef5jxp7');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY');
   $addressList = 'Alice <alice@example.com>,bob@example.com';
 
   # Issue the call to the client.
-  $result = $mgClient->get("address/parse", array('addresses' => $addressList));
+  $result = $mgClient->emailValidation->parse($addressList);
 
 .. code-block:: py
 
@@ -115,7 +115,7 @@
 
   var DOMAIN = 'YOUR_DOMAIN_NAME';
   var mailgun = require('mailgun-js')({ apiKey: "PUBLIC_API_KEY", domain: DOMAIN });
-  
+
   mailgun.parse([ 'alice@example.com', 'bob@example.com', 'fake@email.com' ], function (error, body) {
     console.log(body);
   });

--- a/source/samples/get-route.rst
+++ b/source/samples/get-route.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getSingleRoute() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/routes/YOUR_ROUTE_ID")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,11 +32,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $routeId = '4e97c1b2ba8a48567f007fb6';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $route_id = '5d9fde0fd8b861ec16cf2549'
 
   # Issue the call to the client.
-  $result = $mgClient->get("routes/$routeId");
+  $result = $mgClient->routes()->show($route_id);
 
 .. code-block:: py
 

--- a/source/samples/get-routes.rst
+++ b/source/samples/get-routes.rst
@@ -12,19 +12,19 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getRoutes() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/routes")
              .basicAuth("api", API_KEY)
              .queryString("skip", "0")
              .queryString("limit","5")
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -36,10 +36,10 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
 
   # Issue the call to the client.
-  $result = $mgClient->get("routes", array('skip' => 5, 'limit' => 10));
+  $result = $mgClient->routes()->index();
 
 .. code-block:: py
 

--- a/source/samples/get-stats.rst
+++ b/source/samples/get-stats.rst
@@ -13,13 +13,13 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getStats() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/stats/total")
              .basicAuth("api", API_KEY)
              .queryString("event", "accepted")
@@ -27,7 +27,7 @@
              .queryString("event", "failed")
              .queryString("duration","1m")
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -39,14 +39,18 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
 
-  # Issue the call to the client.
-  $result = $mgClient->get("$domain/stats/total", array(
-      'event' => array('accepted', 'delivered', 'failed'),
-      'duration' => '1m'
-  ));
+  # Define your Event types
+  $params = array(
+    "event" => "accepted",
+    "event" => "delivered",
+    "event" => "failed",
+    "event" => "complained"
+  );
+
+$response = $mgClient->stats()->total($domain, $params);
 
 .. code-block:: py
 

--- a/source/samples/get-tags.rst
+++ b/source/samples/get-tags.rst
@@ -10,18 +10,18 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getTags() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/"+ YOUR_DOMAIN_NAME + "/tags")
              .basicAuth("api", API_KEY)
              .queryString("limit", 10)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -33,13 +33,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
   $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
-  $result = $mgClient->get("$domain/tags", array(
-      'limit' => 10
-  ));
+  $result = $mgClient->tags()->index($domain);
 
 .. code-block:: py
 

--- a/source/samples/get-unsubscribes.rst
+++ b/source/samples/get-unsubscribes.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getUnsubscribes() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/unsubscribes")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,14 +32,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
   $domain = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
-  $result = $mgClient->get("$domain/unsubscribes", array(
-      'limit' => 5,
-      'skip' => 10
-  ));
+  $result = $mgClient->suppressions()->unsubscribes()->index($domain);
 
 .. code-block:: py
 

--- a/source/samples/get-validate.rst
+++ b/source/samples/get-validate.rst
@@ -6,41 +6,50 @@
       --data-urlencode address='foo@mailgun.net'
 
 .. code-block:: java
- 
+
  import com.mashape.unirest.http.HttpResponse;
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode validateEmail() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v4/address/validate")
              .basicAuth("api", PRIVATE_API_KEY)
              .queryString("address", "foo@mailgun.com")
              .asJson();
- 
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support the v4 Validations endpoint.
+  # Consider using the following php curl function.
+  function get_bulk_validation() {
+    $params = array(
+        "address" => "bob@example.com"
+    );
+    $ch = curl_init();
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('PRIVATE_API_KEY');
-  $validateAddress = 'foo@mailgun.net';
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
-  # Issue the call to the client.
-  $result = $mgClient->get("address/validate", array('address' => $validateAddress));
-  # is_valid is 0 or 1
-  $isValid = $result->http_response_body->is_valid;
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v4/address/validate');
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
+
 .. code-block:: py
 
  def get_validate():
@@ -60,46 +69,43 @@
                                        user: 'api', password: public_key
  end
 
-
-.. code-block:: go 
+.. code-block:: go
 
  import (
-	 "encoding/json"
-	 "net/http"
+    "encoding/json"
+    "net/http"
  )
 
  type ValidationResponse struct {
-	 Address       string   `json:"address"`
-	 IsDisposable  bool     `json:"is_disposable_address"`
-	 IsRoleAddress bool     `json:"is_role_address"`
-	 Reason        []string `json:"reason"`
-	 Result        string   `json:"result"`
-	 Risk          string   `json:"risk"`
+    Address       string   `json:"address"`
+    IsDisposable  bool     `json:"is_disposable_address"`
+    IsRoleAddress bool     `json:"is_role_address"`
+    Reason        []string `json:"reason"`
+    Result        string   `json:"result"`
+    Risk          string   `json:"risk"`
  }
 
 
  func validateAddress(email string) (vr ValidationResponse, err error) {
 
-	 // creating HTTP request and returning response
-	
-	 client := &http.Client{}
-	 req, _ := http.NewRequest("GET", "https://api.mailgun.net/v4/address/validate", nil)
-	 req.SetBasicAuth("api", apiKey)
-	 param := req.URL.Query()
-	 param.Add("address", email)
-	 req.URL.RawQuery = param.Encode()
-	 response, err := client.Do(req)
+    // creating HTTP request and returning response
 
- 	 if err != nil {
-		 return
-	 }
+    client := &http.Client{}
+    req, _ := http.NewRequest("GET", "https://api.mailgun.net/v4/address/validate", nil)
+    req.SetBasicAuth("api", apiKey)
+    param := req.URL.Query()
+    param.Add("address", email)
+    req.URL.RawQuery = param.Encode()
+    response, err := client.Do(req)
 
-	 // decoding into validation response struct
-	 err = json.NewDecoder(response.Body).Decode(&vr)
+    if err != nil {
+        return
+    }
 
-	 return
- }
-
+    // decoding into validation response struct
+    err = json.NewDecoder(response.Body).Decode(&vr)
+    return
+    }
 
 .. code-block:: csharp
 

--- a/source/samples/get-webhook.rst
+++ b/source/samples/get-webhook.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getWebhookEvent() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME + "/webhooks/clicked")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,11 +32,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
+  $webhook  = 'delivered';
 
   # Issue the call to the client.
-  $result = $mgClient->get("domains/$domain/webhooks/clicked");
+  $result = $mgClient->webhooks()->show($domain, $webhook)
 
 .. code-block:: py
 

--- a/source/samples/get-webhooks.rst
+++ b/source/samples/get-webhooks.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getWebhooks() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/domains/" + YOUR_DOMAIN_NAME + "/webhooks")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,11 +32,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
-  $result = $mgClient->get("domains/$domain/webhooks");
+  $result = $mgClient->webhooks()->index($domain)
+
 
 .. code-block:: py
 

--- a/source/samples/get-whitelists.rst
+++ b/source/samples/get-whitelists.rst
@@ -10,33 +10,43 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getBounces() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/whitelists")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support Suppression Whiteslist endpoint.
+  # Consider using the following php curl function.
+  function add_domain_whitelist() {
+    $ch = curl_init();
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
-  # Issue the call to the client.
-  $result = $mgClient->get("$domain/whitelists");
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/domain.tld/whitelists');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, array(
+        'address'=> 'bob@example.com')
+    );
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/remove-domain-ip.rst
+++ b/source/samples/remove-domain-ip.rst
@@ -12,15 +12,15 @@
  import com.mashape.unirest.http.exceptions.UnirestException;
 
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode deleteDomainIP() throws UnirestException {
- 
+
          HttpResponse<JsonNode> request = Unirest.delete("https://api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/ips/127.0.0.1")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,12 +32,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $ip = '127.0.0.1';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
+  $ip       = '127.0.0.1';
 
   # Issue the call to the client.
-  $result = $mgClient->delete("$domain/ips/$ip");
+  $result = $mgClient->ips->unassign($domain, $ip);
 
 .. code-block:: py
 

--- a/source/samples/remove-list-member.rst
+++ b/source/samples/remove-list-member.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode removeMembers() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.delete("https://api.mailgun.net/v3/lists/YoungJustice@example.com/members/karen@example.com")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,12 +32,12 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
-  $listMember = 'bar@example.com';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $mailing_list = 'LIST@YOUR_DOMAIN_NAME';
+  $recipient    = 'bob@example.com';
 
   # Issue the call to the client.
-  $result = $mgClient->delete("lists/$listAddress/members/$listMember");
+  $result = $mgClient->mailingList()->member()->delete($mailing_list, $recipient);
 
 .. code-block:: py
 

--- a/source/samples/remove-mailing-list.rst
+++ b/source/samples/remove-mailing-list.rst
@@ -10,17 +10,17 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode removeMailingList() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.delete("https://api.mailgun.net/v3/lists/YoungJustice@example.com")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
@@ -32,11 +32,11 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $mailing_list = 'LIST@YOUR_DOMAIN_NAME';
 
   # Issue the call to the client.
-  $result = $mgClient->delete("lists/$listAddress");
+  $result = $mgClient->mailingList()->delete($mailing_list);
 
 .. code-block:: py
 

--- a/source/samples/resend-simple-message.rst
+++ b/source/samples/resend-simple-message.rst
@@ -28,34 +28,27 @@
 
 .. code-block:: php
 
- $api_key = 'YOUR_API_KEY';
- $storage_url = 'https://se.api.mailgun.net/v3/domains/YOUR_DOMAIN_NAME/messages/STORAGE_URL';
- $payload = http_build_query(
-     array(
-         'to' => array(
-             'user@samples.mailgun.org',
-         ),
-     )
- );
+  # Currently, the PHP SDK does not support Resend Messages endpoint.
+  # Consider using the following php curl function.
+  function resend_message() {
+    $ch = curl_init();
 
- $opts = array(
-   'http' => array(
-     'method' => 'POST',
-     'content' => $payload,
-     'header' => implode("\r\n", array(
-       'Authorization: Basic ' . base64_encode("api:$api_key"),
-       'Content-Type: application/x-www-form-urlencoded',
-     )),
-   ),
- );
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
- print_r($opts);
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+    curl_setopt($ch, CURLOPT_URL, MESSAGE_STORAGE_URL);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, array(
+        'to'=> 'bob@example.com'
+        )
+    );
 
- $context = stream_context_create($opts);
+    $result = curl_exec($ch);
+    curl_close($ch);
 
- $result = file_get_contents($storage_url, false, $context);
- print_r($result);
-
+    return $result;
+  }
 .. code-block:: py
 
  def resend_simple_message():

--- a/source/samples/send-complex-message.rst
+++ b/source/samples/send-complex-message.rst
@@ -51,21 +51,26 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
   $domain = "YOUR_DOMAIN_NAME";
+  $params = array(
+        'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
+        'to'      => 'bob@example.com',
+        'cc'      => 'alice@example.com',
+        'bcc'     => 'john@example.com',
+        'subject' => 'Hello',
+        'text'    => 'Testing some Mailgun awesomness!',
+        'html'    => '<html>HTML version of the body</html>',
+        'attachment' => array(
+                array(
+                    'filePath' => 'test.txt',
+                    'filename' => 'test_file.txt'
+              )
+          )
+      );
 
   # Make the call to the client.
-  $result = $mgClient->sendMessage($domain, array(
-      'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
-      'to'      => 'foo@example.com',
-      'cc'      => 'baz@example.com',
-      'bcc'     => 'bar@example.com',
-      'subject' => 'Hello',
-      'text'    => 'Testing some Mailgun awesomness!',
-      'html'    => '<html>HTML version of the body</html>'
-  ), array(
-      'attachment' => array('/path/to/file.txt', '/path/to/file.txt')
-  ));
+  $result = $mgClient->messages()->send($domain, $params);
 
 .. code-block:: py
 

--- a/source/samples/send-connection.rst
+++ b/source/samples/send-connection.rst
@@ -47,18 +47,20 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
   $domain = "YOUR_DOMAIN_NAME";
+  $params = array(
+        'from'                => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
+        'to'                  => 'bob@example.com',
+        'subject'             => 'Hello',
+        'text'                => 'Testing some Mailgun awesomness!',
+        'html'                => '<html>HTML version of the body</html>',
+        'o:require-tls'       => true,
+        'o:skip-verification' => false
+      );
 
   # Make the call to the client.
-  $result = $mgClient->sendMessage($domain, array(
-      'from'                => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
-      'to'                  => 'foo@example.com',
-      'subject'             => 'Hello',
-      'text'                => 'Testing some Mailgun awesomness!',
-      'o:require-tls'       => true,
-      'o:skip-verification' => false
-  ));
+  $result = $mgClient->messages()->send($domain, $params);
 
 .. code-block:: py
 

--- a/source/samples/send-inline-image.rst
+++ b/source/samples/send-inline-image.rst
@@ -48,21 +48,20 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
   $domain = "YOUR_DOMAIN_NAME";
+  $params = array(
+        'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
+        'to'      => 'bob@example.com',
+        'subject' => 'Hello',
+        'text'    => 'Testing some Mailgun awesomness!',
+        'html'    => '<html>Inline image: <img src="cid:test.jpg"></html>',
+        'inline' => array(
+            array('filePath' => '/path/to/image.jpg'))
+      );
 
-  # Make the call to the client.
-  $result = $mgClient->sendMessage($domain, array(
-      'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
-      'to'      => 'foo@example.com',
-      'cc'      => 'baz@example.com',
-      'bcc'     => 'bar@example.com',
-      'subject' => 'Hello',
-      'text'    => 'Testing some Mailgun awesomness!',
-      'html'    => '<html>Inline image: <img src="cid:test.jpg"></html>'
-  ), array(
-      'inline' => array('/path/to/test.jpg')
-  ));
+    # Make the call to the client.
+    $result = $mgClient->messages()->send($domain, $params);
 
 .. code-block:: py
 

--- a/source/samples/send-message-by-template-id.rst
+++ b/source/samples/send-message-by-template-id.rst
@@ -27,12 +27,12 @@
          HttpResponse<JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/messages")
             .basicAuth("api", API_KEY)
             .field("from", "Excited User <YOU@YOUR_DOMAIN_NAME>")
- 			.field("to", "alice@example.com")
- 	        .field("subject", "Hello")
+            .field("to", "alice@example.com")
+            .field("subject", "Hello")
             .field("template", "template.test")
- 		    .field("o:tracking", "False")
+            .field("o:tracking", "False")
             .field("h:X-Mailgun-Variables", "{\"title\": \"API Documentation\", \"body\": \"Sending messages with templates\"}")
- 		    .asJson();
+            .asJson();
 
          return request.getBody();
      }
@@ -45,17 +45,18 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
   $domain = "YOUR_DOMAIN_NAME";
-
-  # Make the call to the client.
-  $result = $mgClient->sendMessage($domain, array(
+  $params = array(
       'from'                  => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
-      'to'                    => 'foo@example.com',
+      'to'                    => 'bob@example.com',
       'subject'               => 'Hello',
       'template'              => 'template.test',
       'h:X-Mailgun-Variables' => '{"title": "API Documentation", "body": "Sending messages with templates"}'
-  ));
+      );
+
+  # Make the call to the client.
+  $result = $mgClient->messages()->send($domain, $params);
 
 .. code-block:: py
 
@@ -126,13 +127,13 @@
     "github.com/mailgun/mailgun-go"
     "time"
   )
-  
+
 
   func SendMessageWithTemplate() (id string , err error) {
     mg := mailgun.NewMailgun("YOUR_DOMAIN_NAME", "YOUR_API_KEY")
     ctx, cancel := context.WithTimeout(context.Background(), time.Second * 30)
     defer cancel()
-    
+
     m := mg.NewMessage("Excited User <YOU@YOUR_DOMAIN_NAME>", "???", "")
     m.SetTemplate("template.test")
     if err := m.AddRecipient("bar@example.com"); err != nil {

--- a/source/samples/send-message-no-tracking.rst
+++ b/source/samples/send-message-no-tracking.rst
@@ -44,17 +44,19 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
   $domain = "YOUR_DOMAIN_NAME";
 
-  # Make the call to the client.
-  $result = $mgClient->sendMessage($domain, array(
+  $params =  array(
       'from'       => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
       'to'         => 'foo@example.com',
       'subject'    => 'Hello',
       'text'       => 'Testing some Mailgun awesomness!',
       'o:tracking' => false
-  ));
+  );
+
+  # Make the call to the client.
+  $result = $mgClient->messages()->send($domain, $params);
 
 .. code-block:: py
 

--- a/source/samples/send-message-template-v.rst
+++ b/source/samples/send-message-template-v.rst
@@ -28,13 +28,13 @@
          HttpResponse<JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/messages")
             .basicAuth("api", API_KEY)
             .field("from", "Excited User <YOU@YOUR_DOMAIN_NAME>")
- 			.field("to", "alice@example.com")
- 	        .field("subject", "Hello")
+            .field("to", "alice@example.com")
+            .field("subject", "Hello")
             .field("template", "template.test")
- 		    .field("o:tracking", "False")
+            .field("o:tracking", "False")
             .field("v:title": "API Documentation")
             .field("v:body": "Sending messages with templates")
- 		    .asJson();
+            .asJson();
 
          return request.getBody();
      }
@@ -49,16 +49,16 @@
   # Instantiate the client.
   $mgClient = new Mailgun('YOUR_API_KEY');
   $domain = "YOUR_DOMAIN_NAME";
-
-  # Make the call to the client.
-  $result = $mgClient->sendMessage($domain, array(
+  $params = array(
       'from'     => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
       'to'       => 'foo@example.com',
       'subject'  => 'Hello',
       'template' => 'template.test',
       'v:title'  => 'API Documentation',
       'v:body'   => 'Sending messages with templates'
-  ));
+  );
+  # Make the call to the client.
+  $result = $mgClient->messages()->send($domain, $params);
 
 .. code-block:: py
 

--- a/source/samples/send-mime-message.rst
+++ b/source/samples/send-mime-message.rst
@@ -41,17 +41,22 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
   $domain = "YOUR_DOMAIN_NAME";
 
-  # Make the call to the client.
-  $result = $mgClient->sendMessage(
-      $domain, array(
-          'from' => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
-          'to'   => 'foo@example.com'
-      ),
-      '<Pass fully formed MIME string here>'
+  $recipients = array(
+      'bob@example.com',
+      'alice@example.com',
+      'john@example.com;
   );
+  $params = array(
+      'from' => 'Excited User <YOU@YOUR_DOMAIN_NAME>'
+  );
+
+  $mime_string = '<Pass fully formed MIME string here>'
+
+  # Make the call to the client.
+  $result = $mgClient->messages()->sendMime($domain, $recipients, $mime_string, $params);
 
 .. code-block:: py
 

--- a/source/samples/send-scheduled-message.rst
+++ b/source/samples/send-scheduled-message.rst
@@ -44,17 +44,18 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
   $domain = "YOUR_DOMAIN_NAME";
-
-  # Make the call to the client.
-  $result = $mgClient->sendMessage($domain, array(
+  $params = array(
       'from'           => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
-      'to'             => 'Baz <baz@example.com>',
+      'to'             => 'bob@example.com',
       'subject'        => 'Hello',
       'text'           => 'Testing some Mailgun awesomness!',
-      'o:deliverytime' => 'Fri, 25 Oct 2013 23:10:10 -0000'
-  ));
+      'o:deliverytime' => 'Wed, 01 Jan 2020 09:00:00 -0000'
+  );
+
+  # Make the call to the client.
+  $result = $mgClient->messages()->send($domain, $params);
 
 .. code-block:: py
 

--- a/source/samples/send-simple-message.rst
+++ b/source/samples/send-simple-message.rst
@@ -42,17 +42,18 @@
   require 'vendor/autoload.php';
   use Mailgun\Mailgun;
 
-  # First, instantiate the SDK with your API credentials
-  $mg = Mailgun::create('YOUR_API_KEY');
-
-  # Now, compose and send your message.
-  # $mg->messages()->send($domain, $params);
-  $mg->messages()->send('YOUR_DOMAIN_NAME', [
-    'from'    => 'Excited User <mailgun@YOUR_DOMAIN_NAME>',
-    'to'      => 'Baz <YOU@YOUR_DOMAIN_NAME>',
+  # Instantiate the client.
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain = "YOUR_DOMAIN_NAME";
+  $params = array(
+    'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
+    'to'      => 'bob@example.com',
     'subject' => 'Hello',
     'text'    => 'Testing some Mailgun awesomness!'
-  ]);
+  );
+
+  # Make the call to the client.
+  $mg->messages()->send($domain, $params);
 
 .. code-block:: py
 

--- a/source/samples/send-tagged-message.rst
+++ b/source/samples/send-tagged-message.rst
@@ -46,17 +46,18 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
   $domain = "YOUR_DOMAIN_NAME";
-
-  # Make the call to the client.
-  $result = $mgClient->sendMessage($domain, array(
+  $params = array(
       'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
-      'to'      => 'Baz <baz@example.com>',
+      'to'      => 'bob@example.com',
       'subject' => 'Hello',
       'text'    => 'Testing some Mailgun awesomness!',
-      'o:tag'   => array('Tag1', 'Tag2')
-  ));
+      'o:tag'   => array('Tag1', 'Tag2', 'Tag3')
+  );
+
+  # Make the call to the client.
+  $result = $mgClient->messages()->send($domain, $params);
 
 .. code-block:: py
 

--- a/source/samples/send-template-message.rst
+++ b/source/samples/send-template-message.rst
@@ -46,19 +46,19 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
   $domain = "YOUR_DOMAIN_NAME";
-
-  # Make the call to the client.
-  $result = $mgClient->sendMessage($domain, array(
+  $params =  array(
       'from'    => 'Excited User <YOU@YOUR_DOMAIN_NAME>',
       'to'      => array('bob@example.com, alice@example.com'),
       'subject' => 'Hey %recipient.first%',
-      'text'    => 'If you wish to unsubscribe,
-                            click http://mailgun/unsubscribe/%recipient.id%',
-              'recipient-variables' => '{"bob@example.com": {"first":"Bob", "id":1},
-                                         "alice@example.com": {"first":"Alice", "id": 2}}'
-  ));
+      'text'    => 'If you wish to unsubscribe, click http://example.com/unsubscribe/%recipient.id%',
+      'recipient-variables' => '{"bob@example.com": {"first":"Bob", "id":1},
+                                 "alice@example.com": {"first":"Alice", "id": 2}}'
+  );
+
+  # Make the call to the client.
+  $result = $mgClient->messages()-send($domain, $params);
 
 .. code-block:: py
 

--- a/source/samples/templates/create-template-usage.rst
+++ b/source/samples/templates/create-template-usage.rst
@@ -13,40 +13,50 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
       // ...
- 
+
      public static JsonNode createTemplate() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/templates")
- 			.basicAuth("api", API_KEY)
- 			.field("template", "<div class=\"entry\"> <h1>{{title}}</h1> <div class=\"body\"> {{body}} </div> </div>")
+            .basicAuth("api", API_KEY)
+            .field("template", "<div class=\"entry\"> <h1>{{title}}</h1> <div class=\"body\"> {{body}} </div> </div>")
             .field("name", "Test template")
             .field("description", "Sample template")
- 			.asJson();
- 
+            .asJson();
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function add_template() {
+    $params = array(
+      'template'    => '<div class="entry"> <h1>{{title}}</h1> <div class="body"> {{body}} </div> </div>',
+      'name'        => 'Test template',
+      'description' => 'sample_template'
+    );
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+    $ch = curl_init();
 
-  # Issue the call to the client.
-  $result = $mgClient->post("$domain/templates", array(
-      'template' => '<div class="entry"> <h1>{{title}}</h1> <div class="body"> {{body}} </div> </div>',
-      'name' => 'Test template',
-      'description' => 'Sample template'
-  ));
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/templates/template-create-version.rst
+++ b/source/samples/templates/template-create-version.rst
@@ -14,44 +14,54 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
       // ...
- 
+
      public static JsonNode storeVersion() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/templates")
- 			.basicAuth("api", API_KEY)
- 			.field("name", "template.name")
+            .basicAuth("api", API_KEY)
+            .field("name", "template.name")
             .field("description", "template description")
             .field("template", "{{fname}} {{lname}}")
             .field("engine", "handlebars")
             .field("commnt", "version comment")
- 			.asJson();
- 
+            .asJson();
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
-
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-
-  # Issue the call to the client.
-  $result = $mgClient->post("$domain/templates", array(
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function create_template_version() {
+    $params = array(
       'name' => 'template.name',
       'description' => 'template description',
       'template' => '{{fname}} {{lname}}',
       'engine' => 'handlebars',
       'comment' => 'version comment'
-  ));
+    );
+
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/templates/template-create.rst
+++ b/source/samples/templates/template-create.rst
@@ -11,39 +11,48 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
       // ...
- 
+
      public static JsonNode createTemplate() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/templates")
- 			.basicAuth("api", API_KEY)
- 			.field("name", "template.name")
+            .basicAuth("api", API_KEY)
+            .field("name", "template.name")
             .field("description", "template description")
- 			.asJson();
- 
+            .asJson();
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
-
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-
-  # Issue the call to the client.
-  $result = $mgClient->post("$domain/templates", array(
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function create_template() {
+    $params = array(
       'name' => 'template.name',
-      'description' => 'template description'
-  ));
+      'description' => 'template description',
+    );
 
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 .. code-block:: py
 
  def store_template():

--- a/source/samples/templates/template-delete-all.rst
+++ b/source/samples/templates/template-delete-all.rst
@@ -26,16 +26,24 @@
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function delete_all_templates() {
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
+    $ch = curl_init();
 
-  # Issue the call to the client.
-  $result = $mgClient->delete("/$domain/templates");
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates');
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/templates/template-delete.rst
+++ b/source/samples/templates/template-delete.rst
@@ -26,24 +26,24 @@
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function delete_template() {
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $name = 'TEMPLATE_NAME';
+    $ch = curl_init();
 
-  # Issue the call to the client.
-  $result = $mgClient->delete("/$domain/templates/$name");
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
-.. code-block:: py
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME');
 
- def delete_template():
-     return requests.delete(
-         "https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME",
-         auth=("api", "YOUR_API_KEY"))
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: rb
 

--- a/source/samples/templates/template-get-active.rst
+++ b/source/samples/templates/template-get-active.rst
@@ -11,35 +11,47 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getTemplate() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME")
              .basicAuth("api", API_KEY)
               .queryString("active", "yes")
              .asJson();
- 
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function get_active_template() {
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $name = 'TEMPLATE_NAME';
+    $params = array(
+        'active' => 'yes'
+    );
 
-  # Issue the call to the client.
-  $result = $mgClient->get("$domain/templates/$name", array('active' => 'yes'));
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/templates/template-get-all.rst
+++ b/source/samples/templates/template-get-all.rst
@@ -10,34 +10,42 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode listTemplates() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/templates")
              .basicAuth("api", API_KEY)
              .queryString("limit","10")
              .asJson();
- 
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function get_templates() {
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  
-  # Issue the call to the client.
-  $result = $mgClient->get("$domain/templates", array('limit' => 10));
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates');
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/templates/template-get.rst
+++ b/source/samples/templates/template-get.rst
@@ -10,34 +10,41 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getTemplate() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function get_template() {
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $name = 'TEMPLATE_NAME';
+    $ch = curl_init();
 
-  # Issue the call to the client.
-  $result = $mgClient->get("$domain/templates/$name");
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME');
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/templates/template-update.rst
+++ b/source/samples/templates/template-update.rst
@@ -29,19 +29,28 @@
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
-
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $name = 'TEMPLATE_NAME'
-
-  # Issue the call to the client.
-  $result = $mgClient->put("$domain/templates/$name", array(
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function update_template() {
+    $params = array(
       'description' => 'new template description'
-  ));
+    );
+
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/templates/version-create.rst
+++ b/source/samples/templates/version-create.rst
@@ -12,41 +12,50 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
       // ...
- 
+
      public static JsonNode storeTemplateVersion() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.post("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/templates/TEMPLATE_NAME/versions")
- 			.basicAuth("api", API_KEY)
+            .basicAuth("api", API_KEY)
             .field("tag", "v0")
- 			.field("template", "{{fname}} {{lname}}")
+            .field("template", "{{fname}} {{lname}}")
             .field("engine", "handlebars")
- 			.asJson();
- 
+            .asJson();
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
-
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $name = 'TEMPLATE_NAME'
-
-  # Issue the call to the client.
-  $result = $mgClient->post("$domain/templates/$name/versions", array(
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function create_template_version() {
+    $params = array(
       'tag' => 'v0',
       'template' => '{{fname}} {{lname}}',
       'engine' => 'handlebars'
-  ));
+    );
+
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME/versions');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/templates/version-delete.rst
+++ b/source/samples/templates/version-delete.rst
@@ -9,36 +9,42 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode deleteTemplateVersion() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.delete (
                                 "https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/templates/TEMPLATE_NAME/versions/VERSION_TAG")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function delete_template_version() {
+    $ch = curl_init();
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $name = 'TEMPLATE_NAME'
-  $tag = 'VERSION_TAG'
-  
-  # Issue the call to the client.
-  $result = $mgClient->delete("$domain/templates/$name/versions/$tag");
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'DELETE');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME/versions/VERSION_TAG');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 
@@ -52,7 +58,7 @@
  def delete_template_version
    RestClient.get "https://api:YOUR_API_KEY"\
    "@api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME/versions/VERSION_TAG"
-   
+
  end
 
 .. code-block:: csharp

--- a/source/samples/templates/version-get-all.rst
+++ b/source/samples/templates/version-get-all.rst
@@ -10,34 +10,40 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode listTemplateVersions() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/templates/TEMPLATE_NAME/versions")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function get_all_versions() {
+    $ch = curl_init();
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $name = 'TEMPLATE_NAME'
-  
-  # Issue the call to the client.
-  $result = $mgClient->get("$domain/templates/$name/versions");
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME/versions');
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 

--- a/source/samples/templates/version-get.rst
+++ b/source/samples/templates/version-get.rst
@@ -9,35 +9,42 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
      // ...
- 
+
      public static JsonNode getTemplateVersion() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.get("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/templates/TEMPLATE_NAME/versions/VERSION_TAG")
              .basicAuth("api", API_KEY)
              .asJson();
- 
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function get_template_version() {
 
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $name = 'TEMPLATE_NAME'
-  $tag  = 'VERSION_TAG'
-  
-  # Issue the call to the client.
-  $result = $mgClient->get("$domain/templates/$name/versions/$tag");
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'GET');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME/versions/VERSION_TAG');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
 
 .. code-block:: py
 
@@ -50,7 +57,7 @@
 
  def get_template_version
    RestClient.get "https://api:YOUR_API_KEY"\
-   "@api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME/versions/VERSION_TAG" 
+   "@api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME/versions/VERSION_TAG"
  end
 
 .. code-block:: csharp
@@ -80,7 +87,7 @@
          request.AddParameter ("domain", "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
          request.AddParameter ("name", "TEMPLATE_NAME", ParameterType.UrlSegment);
          request.AddParameter ("tag", "VERSION_TAG", ParameterType.UrlSegment);
-         
+
          return client.Execute (request);
      }
 

--- a/source/samples/templates/version-update.rst
+++ b/source/samples/templates/version-update.rst
@@ -12,42 +12,51 @@
  import com.mashape.unirest.http.JsonNode;
  import com.mashape.unirest.http.Unirest;
  import com.mashape.unirest.http.exceptions.UnirestException;
- 
+
  public class MGSample {
- 
+
       // ...
- 
+
      public static JsonNode UpdateVersion() throws UnirestException {
- 
+
          HttpResponse <JsonNode> request = Unirest.put("https://api.mailgun.net/v3/" + YOUR_DOMAIN_NAME + "/templates/TEMPLATE_NAME/versions/VERSION_TAG")
- 			.basicAuth("api", API_KEY)
- 			.field("template", "{{fname}} {{lname}}")
+            .basicAuth("api", API_KEY)
+            .field("template", "{{fname}} {{lname}}")
             .field("comment", "Updated version comment")
             .field("active", "yes")
- 			.asJson();
- 
+            .asJson();
+
          return request.getBody();
      }
  }
 
 .. code-block:: php
 
-  # Include the Autoloader (see "Libraries" for install instructions)
-  require 'vendor/autoload.php';
-  use Mailgun\Mailgun;
-
-  # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $domain = 'YOUR_DOMAIN_NAME';
-  $name = 'TEMPLATE_NAME'
-  $tag = 'VERSION_TAG'
-
-  # Issue the call to the client.
-  $result = $mgClient->put("$domain/templates/$name/versions/$tag", array(
+  # Currently, the PHP SDK does not support the Templates endpoint.
+  # Consider using the following php curl function.
+  function update_template_version() {
+    $params =   array(
       'template' => '{{fname}} {{lname}}',
       'comment' => 'Updated version comment',
       'active' => 'yes'
-  ));
+    );
+
+    $ch = curl_init();
+
+    curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+    curl_setopt($ch, CURLOPT_USERPWD, 'api:PRIVATE_API_KEY');
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+
+    curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'PUT');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME/versions/VERSION_TAG');
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
+
+    $result = curl_exec($ch);
+    curl_close($ch);
+
+    return $result;
+  }
+
 
 .. code-block:: py
 
@@ -61,7 +70,7 @@
 
 .. code-block:: rb
 
- def update_version: 
+ def update_version:
    RestClient.put "https://api:YOUR_API_KEY"\
    "@api.mailgun.net/v3/YOUR_DOMAIN_NAME/templates/TEMPLATE_NAME/versions/VERSION_TAG",
    :template => '{{fname}} {{lname}}',

--- a/source/samples/update-connection.rst
+++ b/source/samples/update-connection.rst
@@ -36,13 +36,13 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain = "YOUR_DOMAIN_NAME";
+  $require_tls = true;
+  $skip_verification = false;
 
   # Issue the call to the client.
-  $result = $mgClient->put("domains/$domain/connection", array(
-      'require_tls'       => 'true',
-      'skip_verification' => 'false'
-  ));
+  $result = $mgClient->domains()->updateConnection($domain, $require_tls, $skip_verification);
 
 .. code-block:: py
 

--- a/source/samples/update-list-member.rst
+++ b/source/samples/update-list-member.rst
@@ -36,15 +36,17 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'LIST@YOUR_DOMAIN_NAME';
-  $memberAddress = 'bob@example.com';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $mailing_list = 'LIST@YOUR_DOMAIN_NAME';
+  $recipient    = 'bob@example.com';
+  $params = array(
+      'name'      => 'Bob',
+      'subscribed => 'yes',
+      'vars'      => '{"age": 30, "pet": "cat"}'
+  );
 
   # Issue the call to the client.
-  $result = $mgClient->put("lists/$listAddress/members/$memberAddress", http_build_query(array(
-      'subscribed' => false,
-      'name'       => 'Foo Bar'
-  )));
+  $result = $mgClient->mailingList()->member()->update($mailing_list, $recipient, $params);
 
 .. code-block:: py
 

--- a/source/samples/update-webhook.rst
+++ b/source/samples/update-webhook.rst
@@ -34,14 +34,13 @@
   use Mailgun\Mailgun;
 
   # Instantiate the client.
-  $mgClient = new Mailgun('YOUR_API_KEY');
-  $listAddress = 'YOUR_DOMAIN_NAME';
-  $memberAddress = 'bob@example.com';
+  $mgClient = Mailgun::create('PRIVATE_API_KEY', 'https://API_HOSTNAME');
+  $domain   = 'YOUR_DOMAIN_NAME';
+  $webhook  = 'delivered';
+  $destination_url = 'https://my.webhook.url/delivered'
 
   # Issue the call to the client.
-  $result = $mgClient->put("$domain/webhooks/clicked", array(
-      'url' => 'https://your_domain.com/clicked'
-  ));
+  $result = $mgClient->webhooks()->update($domain, $webhook, $destination_url);
 
 .. code-block:: py
 


### PR DESCRIPTION
Update the API examples to utilize v3 of the [PHP SDK](https://github.com/mailgun/mailgun-php) and create example functions for endpoints that are not currently supported by the SDK. 