### PR TITLE
Allow for IPv6, correct indentation

### DIFF
--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -2148,9 +2148,10 @@ For more information see Exim's documentation for authenticated outgoing SMTP. Y
   		route_list = * smtp.mailgun.org byname
 
 	# In transports configuration:
-		mailgun_transport:
+	mailgun_transport:
   		driver=smtp
-  		hosts_try_auth = smtp.mailgun.org
+  		hosts_require_auth = <; $host_address
+  		hosts_require_tls = <; $host_address
 
 Also make sure to configure login credentials (in your /etc/exim/passwd.client)::
 


### PR DESCRIPTION
I'd been successfully sending email some of the time using the existing example, but also seeing some `550 5.7.1 Relaying denied` failures; I think this change does the trick. I found this at https://serverfault.com/a/731598/563221 -- the source cited there ([archived](https://web.archive.org/web/20170627085127/http://kb.philross.co.uk/2008/03/15/configuring-exim-to-use-gmail-as-a-smarthost/)) says

> $host_address is used for hosts_require_auth and hosts_require_tls instead of smtp.gmail.com to avoid occasional 530 5.5.1 Authentication Required errors. These are caused by the changing IP addresses in DNS queries for smtp.gmail.com. $host_address will expand to the particular IP address that was resolved by the gmail_route router.
>
> <; is required for the hosts_require_auth and hosts_require_tls lists because $host_address can contain colons (the default list separator character) when sending with IPv6.

[The docs](https://www.exim.org/exim-html-current/doc/html/spec_html/ch-domain_host_address_and_local_part_lists.html) say "The separator is changed to semicolon by the leading “<;” at the start of the list."