### PR TITLE
Correct PHP Library instructions

### DIFF
--- a/source/libraries.rst
+++ b/source/libraries.rst
@@ -177,7 +177,7 @@ load the Mailgun library in your project.
 
     require 'vendor/autoload.php';
     use Mailgun\Mailgun;
-    $mailgun = new Mailgun::create('key-example');
+    $mailgun = Mailgun::create('key-example');
 
 For additional information, see the GitHub Repository `README <https://github.com/mailgun/mailgun-php>`_ file.
 


### PR DESCRIPTION
The `create` method will return the `Mailgun` object, the `new` keyword causes an error