### PR TITLE
Fix characters not allowed in template name

### DIFF
--- a/source/samples/templates/create-template-usage.rst
+++ b/source/samples/templates/create-template-usage.rst
@@ -166,7 +166,7 @@
 
  mailgun.post(`/${DOMAIN}/templates`,
               {"template" : "<div class=\"entry\"> <h1>{{title}}</h1> <div class=\"body\"> {{body}} </div> </div>",
-               "name": "Test template"
+               "name": "template.test"
                "description": "Sample template"},
                                function (error, body) {
                                         console.log(body);


### PR DESCRIPTION
The template name does not contain valid characters such as: [a-z0-9.-_~]