### PR TITLE
Fix incorrect openspf URLs

### DIFF
--- a/source/quickstart-sending.rst
+++ b/source/quickstart-sending.rst
@@ -120,7 +120,7 @@ CNAME     "mailgun.org"                                               Tracking (
 
 .. note:: While the CNAME is listed as optional, it is required to enable Unsubscribe and Click tracking links. 
 
-.. _SPF Information: http://www.openspf.org/Introduction
+.. _SPF Information: http://www.open-spf.org/Introduction
 .. _DKIM Information: http://www.dkim.org/#introduction
 
 Add Receiving MX Records

--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -58,7 +58,7 @@ records found in the **Domain Verification & DNS** section of the domain
 settings page of the Mailgun control panel to your DNS provider:
 
 - SPF: Sending server IP validation. Used by majority of email service
-  providers. `Learn about SPF <http://www.openspf.org/Introduction>`_.
+  providers. `Learn about SPF <http://www.open-spf.org/Introduction>`_.
 - DKIM: Like SPF, but uses cryptographic methods for validation. Supported
   by many email service providers. This is the record that Mailgun references
   make sure that the domain actually belongs to you.


### PR DESCRIPTION
This commit fixes incorrect sender policy framework URLs across the docs.

Old/Incorrect URL: http://www.openspf.org/Introduction
Correct URL: http://www.open-spf.org/Introduction