### PR TITLE
PIP-891: POST /lists/<list>/members.json Documentation Update

### DIFF
--- a/source/api-mailinglists.rst
+++ b/source/api-mailinglists.rst
@@ -183,6 +183,7 @@ Adds multiple members, up to 1,000 per call, to a Mailing List.
  ================== =======================================================
  members            JSON-encoded array. Elements can be either addresses, e.g. ``["bob@example.com", "alice@example.com"]``,
                     or JSON objects, e.g. ``[{"address": "bob@example.com", "name": "Bob", "subscribed": false}, {"address": "alice@example.com", "name": "Alice"}]`` . Custom variables can be provided, see examples.
+                    When passing a JSON object ``subscribed`` will always be set to ``true`` if a value is not passed for it per member.
  upsert             ``yes`` to update existing members, ``no`` (default) to ignore duplicates
  ================== =======================================================
 


### PR DESCRIPTION
This pull request updates the documentation for the `POST /lists/<list>/members.json` API call for mailing lists to let users know if they do not include the `"subscribed"` key with a value in each member in the list they pass the value will default to `true`.