### PR TITLE
Update quickstart-sending.rst

### DIFF
--- a/source/quickstart-sending.rst
+++ b/source/quickstart-sending.rst
@@ -47,7 +47,7 @@ Run this:
 
 .. include:: samples/send-simple-message.rst
 
-*NOTE: If you're sending from our EU infrastructure, be sure to substitute our EU endpoint in the above example: https://api.eu.mailgun.net/v3*
+*NOTE: If you're sending from our EU infrastructure, be sure to substitute the beginning of the endpoint "https://api.mailgun.net" with "https://api.eu.mailgun.net"*
 
 What actually happened:
 


### PR DESCRIPTION
Line 50 "NOTE: If you’re sending from our EU infrastructure, be sure to substitute our EU endpoint in the above example: https://api.eu.mailgun.net/v3" Is what the note currently is. Does not correctly represent Node.js and PHP. 
The proposed change is more inclusive of the EU endpoint for all languages,