### PR TITLE
Add Node.js example for sending via SMTP

### DIFF
--- a/source/samples/smtp-send-simple-message.rst
+++ b/source/samples/smtp-send-simple-message.rst
@@ -190,3 +190,32 @@
         panic(err)
      }
  }
+
+.. code-block:: js
+
+// Using Nodemailer https://nodemailer.com/
+const nodemailer = require("nodemailer");
+
+async function main() {
+  // create reusable transporter object using the default SMTP transport
+  let transporter = nodemailer.createTransport({
+    host: "smtp.mailgun.org",
+    port: 587,
+    auth: {
+      user: "postmaster@YOUR_DOMAIN_NAME",
+      pass: "YOUR_SMTP_PASSWORD", 
+    },
+  });
+
+  // send mail with defined transport object
+  let info = await transporter.sendMail({
+    from: 'foo@YOUR_DOMAIN_NAME', 
+    to: "bar@example.com", 
+    subject: "Hello",
+    text: "Testing some Mailgun awesomness" 
+  });
+
+  console.log("Message sent: %s", info.messageId);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
Support request to add Node.js example for sending via SMTP. Currently the documentation shows nothing when the user selects Node.js for the code example.