### PR TITLE
patch forethought in layout.html

### DIFF
--- a/source/_templates/layout.html
+++ b/source/_templates/layout.html
@@ -753,7 +753,7 @@
   type="application/javascript"
   data-api-key="3112e6a2-5709-439c-bc2c-7bd49d2b22db"
   data-ft-location="docs"
-  data-ft-language="">
+  data-ft-language="en">
 </script>
 
 {%- endblock %}


### PR DESCRIPTION
Changing data-ft-language=""
to data-ft-language="en"

Since the MG widget is now language-aware, it must have one of the corresponding language values:  "es" or "en".