### PR TITLE
Add documentation for IBP test create endpoint

### DIFF
--- a/source/api-deliverability-alerts.rst
+++ b/source/api-deliverability-alerts.rst
@@ -24,6 +24,8 @@ The current list of events that you can chose to receive alerts for are:
 - ``ip_delisted``: A monitored IP has been removed from a blocklist.
 - ``validation_job``: A bulk email verification job has completed.
 - ``validation_preview``: A bulk email verification preview job has completed.
+- ``domain_listed``: A monitored domain has been added to a blocklist.
+- ``domain_delisted``: A monitored domain has been removed from a blocklist.
 
 
 Add Alert

--- a/source/api-inbox-placement.rst
+++ b/source/api-inbox-placement.rst
@@ -751,7 +751,7 @@ sending_domain           string       Required. The domain from which the email 
 from                     string       Required. The email address from which the email should be sent.
 subject                  string       Required. The subject of the email.
 html                     string       Required. The body of the email represented in HTML.
-provider_filter          list         Optional. A list of provider domains for which you wish to test inbox placement.
+provider_filter          list         Optional. A list of provider domains. This field can be used to test inbox placement against a subset of provider(s). See the List Providers section for available providers.
 seedlist                 string       Optional. The identifier for the seedlist you wish to use.
 =====================    =========    ======================================================================================================================
 
@@ -767,3 +767,33 @@ Below is an example of the returned response body.
       "results": "https://api.mailgun.net/v4/inbox/results/1a066d4a-2207-4240-9e89-9e1a55511f0e"
     }
  }
+
+List Providers
+--------------
+
+Use this endpoint to retrieve a list of providers available for Inbox Placement testing.
+
+.. code-block:: url
+
+   GET /v4/inbox/providers
+
+
+Below is an example of the returned response body.
+
+.. code-block:: javascript
+
+  {
+    "items": [
+      {
+        "domain": "hotmail.com",
+        "display_name": "Hotmail",
+        "region": "Global",
+      },
+      {
+        "domain": "gmail.com",
+        "display_name": "Gmail",
+        "region": "Global",
+      },
+      ...
+    ]
+  }

--- a/source/api-inbox-placement.rst
+++ b/source/api-inbox-placement.rst
@@ -278,8 +278,6 @@ You can select a single seed list with this endpoint.
 
    GET /v4/inbox/seedlists/ibp-seedlist-address@domain.net
 
-.. include:: samples/create-inbox-placement-test.rst
-
 Example response of getting a single seed list.
 
 .. code-block:: javascript
@@ -757,7 +755,7 @@ provider_filter          list         Optional. A list of provider domains for w
 seedlist                 string       Optional. The identifier for the seedlist you wish to use.
 =====================    =========    ======================================================================================================================
 
-.. include:: samples/delete-results.rst
+.. include:: samples/create-inbox-placement-test.rst
 
 Below is an example of the returned response body.
 

--- a/source/api-inbox-placement.rst
+++ b/source/api-inbox-placement.rst
@@ -732,3 +732,40 @@ Use this endpoint to delete a result.
 .. include:: samples/delete-results.rst
 
 This does not return any value.
+
+
+Create a test
+-------------
+
+Use this endpoint to create an Inbox Placement test.
+
+.. code-block:: url
+
+   POST /v4/inbox/tests
+
+
+Field Explanation:
+
+=====================    =========    ======================================================================================================================
+Name                     Type         Description
+=====================    =========    ======================================================================================================================
+sending_domain           string       Required. The domain from which the email should be sent. Note, the provided domain must be verified within your Mailgun account.
+from                     string       Required. The email address from which the email should be sent.
+subject                  string       Required. The subject of the email.
+html                     string       Required. The body of the email represented in HTML.
+provider_filter          list         Optional. A list of provider domains for which you wish to test inbox placement.
+seedlist                 string       Optional. The identifier for the seedlist you wish to use.
+=====================    =========    ======================================================================================================================
+
+.. include:: samples/delete-results.rst
+
+Below is an example of the returned response body.
+
+.. code-block:: javascript
+
+ {
+    "result_id": "1a066d4a-2207-4240-9e89-9e1a55511f0e",
+    "links": {
+      "results": "https://api.mailgun.net/v4/inbox/results/1a066d4a-2207-4240-9e89-9e1a55511f0e"
+    }
+ }

--- a/source/api-inbox-placement.rst
+++ b/source/api-inbox-placement.rst
@@ -731,7 +731,6 @@ Use this endpoint to delete a result.
 
 This does not return any value.
 
-
 Create a test
 -------------
 
@@ -740,7 +739,6 @@ Use this endpoint to create an Inbox Placement test.
 .. code-block:: url
 
    POST /v4/inbox/tests
-
 
 Field Explanation:
 
@@ -776,7 +774,6 @@ Use this endpoint to retrieve a list of providers available for Inbox Placement 
 .. code-block:: url
 
    GET /v4/inbox/providers
-
 
 Below is an example of the returned response body.
 

--- a/source/samples/create-inbox-placement-test.rst
+++ b/source/samples/create-inbox-placement-test.rst
@@ -1,11 +1,12 @@
 .. code-block:: bash
 
-  curl -X POST https://api.mailgun.net/v3/inbox/tests \
-    -F 'domain=domain.com' \
+  curl -X POST https://api.mailgun.net/v4/inbox/tests \
+    -F 'sending_domain=domain.com' \
     -F 'subject=testSubject' \
-    -F 'from=user@sending_domain.com' \
+    -F 'from=user@domain.com' \
     --form-string html='<html>HTML version of the body</html>' \
     --user 'api:<YOUR_API_KEY'>'
+
 .. code-block:: java
 
  import com.mashape.unirest.http.HttpResponse;
@@ -17,13 +18,13 @@
 
      // ...
 
-     public static JsonNode validateMailingList() throws UnirestException {
+     public static JsonNode createInboxPlacementTest() throws UnirestException {
 
-         HttpResponse <JsonNode> request = Unirest.post("https://api.mailgun.net/v3/inbox/tests")
+         HttpResponse <JsonNode> request = Unirest.post("https://api.mailgun.net/v4/inbox/tests")
              .basicAuth("api", API_KEY)
-             .field("domain", "domain.com")
+             .field("sending_domain", "domain.com")
              .field("subject", "testSubject")
-             .field("from", "user@sending_domain.com")
+             .field("from", "Sample User <user@domain.com>")
              .field("html", "<html>HTML version of the body</html>")
              .asJson();
 
@@ -43,10 +44,10 @@
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
     curl_setopt($ch, CURLOPT_CUSTOMREQUEST, 'POST');
-    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v3/inbox/tests');
+    curl_setopt($ch, CURLOPT_URL, 'https://api.mailgun.net/v4/inbox/tests');
     curl_setopt($ch, CURLOPT_POSTFIELDS, array(
-        'domain'=> 'domain.com',
-        'from'=> 'user@sending_domain.com',
+        'sending_domain'=> 'domain.com',
+        'from'=> 'Sample User <user@domain.com>',
         'subject'=>'testSubject',
         'html'=>'<html>HTML version of the body</html>',
         )
@@ -61,24 +62,24 @@
 .. code-block:: py
 
  def create_inbox_placement_test():
-     data = {'domain': 'domain.com',
-             'from': 'user@sending_domain.com',
+     data = {'sending_domain': 'domain.com',
+             'from': 'Sample User <user@domain.com>',
              'subject': 'testSubject',
              'html': '<html>HTML version of the body</html>' }
      return requests.post(
-         "https://api.mailgun.net/v3/inbox/tests",
+         "https://api.mailgun.net/v4/inbox/tests",
          data=json.dumps(data),
          auth=('api', 'YOUR_API_KEY'))
 
 .. code-block:: rb
 
- def validate_mailing_list
-   data = {'domain'=> 'domain.com',
-           'from'=> 'user@sending_domain.com',
+ def create_inbox_placement_test
+   data = {'sending_domain'=> 'domain.com',
+           'from'=> 'Sample User <user@domain.com>',
            'subject'=> 'testSubject',
            'html'=> '<html>HTML version of the body</html>' }
    RestClient.post("https://api:YOUR_API_KEY" \
-                   "@api.mailgun.net/v3/inbox/tests",
+                   "@api.mailgun.net/v4/inbox/tests",
                    fields_hash.merge(data))
  end
 
@@ -100,14 +101,14 @@
      public static IRestResponse StartInboxPlacementTest ()
      {
          RestClient client = new RestClient ();
-         client.BaseUrl = new Uri ("https://api.mailgun.net/v3");
+         client.BaseUrl = new Uri ("https://api.mailgun.net/v4");
          client.Authenticator =
              new HttpBasicAuthenticator ("api",
                                          "YOUR_API_KEY");
          RestRequest request = new RestRequest ();
-         request.AddParameter ("domain", "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
+         request.AddParameter ("sending_domain", "YOUR_DOMAIN_NAME", ParameterType.UrlSegment);
          request.Resource = "inbox/tests";
-         request.AddParameter ("from", "user@sending_domain.com'");
+         request.AddParameter ("from", "Sample User <user@domain.com>");
          request.AddParameter ("domain", "domain.com");
          request.AddParameter ("subject", "testSubject");
          request.AddParameter ("html", "<html>HTML version of the body</html>");


### PR DESCRIPTION
This PR:

- documents `POST /v4/inbox/tests`.
- documents `GET /v4/inbox/providers`.
- adds `domain_listed/delisted` events to the alerts docs.