### PR TITLE
Add Total field to the temporary failed stats

### DIFF
--- a/source/api-stats.rst
+++ b/source/api-stats.rst
@@ -130,7 +130,8 @@ Sample response:
              "total": 10                 // failed permanently and dropped
            },
            "temporary": {
-             "espblock": 1   // failed temporary due to ESP block, will be retried
+             "espblock": 1,   // failed temporary due to ESP block, will be retried
+             "total": 1
            }
          },
        }


### PR DESCRIPTION
Total field is missing from the docs although it's present in the Stats response.
Should some sort of comment be added or is it self-explanatory?
Found by https://github.com/mailgun/mailgun-go/pull/298