### PR TITLE
Fix API example response for "View a single whitelist record"

### DIFF
--- a/source/api-suppressions.rst
+++ b/source/api-suppressions.rst
@@ -809,7 +809,7 @@ Expected responses:
       200
       {
         "value": "alice@example.com",
-        "reason": "why the record was created"
+        "reason": "why the record was created",
         "type": "address",
         "createdAt": "Fri, 21 Oct 2011 11:02:55 GMT"
       }


### PR DESCRIPTION
Fix a missing comma in the example response for "View a single whitelist record"