### PR TITLE
Alycrase

### DIFF
--- a/source/inboxready_api_reference.rst
+++ b/source/inboxready_api_reference.rst
@@ -1,6 +1,6 @@
 .. _inboxready-api-reference:
 
-InboxReady API Reference
+Optimize API Reference
 ########################
 
 .. toctree::

--- a/source/user_manual.rst
+++ b/source/user_manual.rst
@@ -1624,7 +1624,7 @@ Parsed Messages Parameters
                                     from ``From`` MIME header.
  from                  string       sender of the message as reported by ``From`` message header, for example "Bob <bob@example.com>".
  subject               string       subject string.
- body-plain            string       text version of the email. This field is always present.
+ body-plain            string       The text version of the email. This field is always present. When only sending attachements, the plain-body field will not be visisble.
                                     If the incoming message only has HTML body, Mailgun will create a text representation for you.
  stripped-text         string       text version of the message without quoted parts and signature block (if found).
  stripped-signature    string       the signature block stripped from the plain text message (if found).


### PR DESCRIPTION
We have one point of feedback regarding the body-plain field. For context, a user sent an email with only attachments. Due to that, our system doesn't include the body-plain field. I've made a change to the content to address that.